### PR TITLE
Update CBMC starter kit to v2.4

### DIFF
--- a/.gitmodules
+++ b/.gitmodules
@@ -1,6 +1,3 @@
-[submodule "cbmc-templates"]
-	path = tests/cbmc/templates
-	url = https://github.com/awslabs/aws-templates-for-cbmc-proofs
 [submodule "tests/cbmc/aws-verification-model-for-libcrypto"]
 	path = tests/cbmc/aws-verification-model-for-libcrypto
 	url = https://github.com/awslabs/aws-verification-model-for-libcrypto.git

--- a/pq-crypto/sike_r1/ec_isogeny_r1.c
+++ b/pq-crypto/sike_r1/ec_isogeny_r1.c
@@ -31,11 +31,10 @@ void xDBLe(const point_proj_t P, point_proj_t Q, const f2elm_t *A24plus, const f
 { // Computes [2^e](X:Z) on Montgomery curve with projective constant via e repeated doublings.
   // Input: projective Montgomery x-coordinates P = (XP:ZP), such that xP=XP/ZP and Montgomery curve constants A+2C and 4C.
   // Output: projective Montgomery x-coordinates Q <- (2^e)*P.
-    int i;
     
     copy_words((const digit_t*)P, (digit_t*)Q, 2*2*NWORDS_FIELD);
 
-    for (i = 0; i < e; i++) {
+    for (int i = 0; i < e; i++) {
         xDBL(Q, Q, A24plus, C24);
     }
 }
@@ -121,11 +120,10 @@ void xTPLe(const point_proj_t P, point_proj_t Q, const f2elm_t *A24minus, const 
 { // Computes [3^e](X:Z) on Montgomery curve with projective constant via e repeated triplings.
   // Input: projective Montgomery x-coordinates P = (XP:ZP), such that xP=XP/ZP and Montgomery curve constants A24plus = A+2C and A24minus = A-2C.
   // Output: projective Montgomery x-coordinates Q <- (3^e)*P.
-    int i;
         
     copy_words((const digit_t*)P, (digit_t*)Q, 2*2*NWORDS_FIELD);
 
-    for (i = 0; i < e; i++) {
+    for (int i = 0; i < e; i++) {
         xTPL(Q, Q, A24minus, A24plus);
     }
 }
@@ -342,5 +340,49 @@ static void LADDER3PT(const f2elm_t *xP, const f2elm_t *xQ, const f2elm_t *xPQ, 
         swap_points(R, R2, mask);
         xDBLADD(R0, R2, &R->X, A24);
         fp2mul_mont(&R2->X, &R->Z, &R2->X);
+    }
+}
+
+void xTPL_fast(const point_proj_t P, point_proj_t Q, const f2elm_t *A2)
+{ // Montgomery curve (E: y^2 = x^3 + A*x^2 + x) x-only tripling at a cost of 5M + 6S + 11A.
+  // Input : projective Montgomery x-coordinates P = (X:Z), where x=X/Z and Montgomery curve constant A/2.
+  // Output: projective Montgomery x-coordinates Q = 3*P = (X3:Z3).
+    f2elm_t _t1, _t2, _t3, _t4;
+    f2elm_t *t1=&_t1, *t2=&_t2, *t3=&_t3, *t4=&_t4;
+
+    fp2sqr_mont(&P->X, t1);       // t1 = x^2
+    fp2sqr_mont(&P->Z, t2);       // t2 = z^2
+    fp2add(t1, t2, t3);           // t3 = t1 + t2
+    fp2add(&P->X, &P->Z, t4);       // t4 = x + z
+    fp2sqr_mont(t4, t4);          // t4 = t4^2
+    fp2sub(t4, t3, t4);           // t4 = t4 - t3
+    fp2mul_mont(A2, t4, t4);      // t4 = t4*A2
+    fp2add(t3, t4, t4);           // t4 = t4 + t3
+    fp2sub(t1, t2, t3);           // t3 = t1 - t2
+    fp2sqr_mont(t3, t3);          // t3 = t3^2
+    fp2mul_mont(t1, t4, t1);      // t1 = t1*t4
+    fp2add(t1, t1, t1);           // t1 = 2*t1
+    fp2add(t1, t1, t1);           // t1 = 4*t1
+    fp2sub(t1, t3, t1);           // t1 = t1 - t3
+    fp2sqr_mont(t1, t1);          // t1 = t1^2
+    fp2mul_mont(t2, t4, t2);      // t2 = t2*t4
+    fp2add(t2, t2, t2);           // t2 = 2*t2
+    fp2add(t2, t2, t2);           // t2 = 4*t2
+    fp2sub(t2, t3, t2);           // t2 = t2 - t3
+    fp2sqr_mont(t2, t2);          // t2 = t2^2
+    fp2mul_mont(&P->X, t2, &Q->X);  // x = x*t2
+    fp2mul_mont(&P->Z, t1, &Q->Z);  // z = z*t1
+}
+
+
+void xTPLe_fast(point_proj_t P, point_proj_t Q, const f2elm_t *A2, int e)
+{ // Computes [3^e](X:Z) on Montgomery curve with projective constant via e repeated triplings. e triplings in E costs e*(5M + 6S + 11A)
+  // Input: projective Montgomery x-coordinates P = (X:Z), where x=X/Z, Montgomery curve constant A2 = A/2 and the number of triplings e.
+  // Output: projective Montgomery x-coordinates Q <- [3^e]P.
+
+    copy_words((digit_t*)P, (digit_t*)Q, 2 * 2 * NWORDS_FIELD);
+
+    for (int i = 0; i < e; i++) {
+        xTPL_fast(Q, Q, A2);
     }
 }

--- a/pq-crypto/sike_r1/fpx_r1.c
+++ b/pq-crypto/sike_r1/fpx_r1.c
@@ -333,6 +333,17 @@ void from_fp2mont(const f2elm_t *ma, f2elm_t *c)
     from_mont(ma->e[1], c->e[1]);
 }
 
+unsigned int is_felm_zero(const felm_t x)
+{ // Is x = 0? return 1 (TRUE) if condition is true, 0 (FALSE) otherwise.
+  // SECURITY NOTE: This function does not run in constant-time.
+
+    for (unsigned int i = 0; i < NWORDS_FIELD; i++) {
+        if (x[i] != 0) {
+            return 0;
+        }
+    }
+    return 1;
+}
 
 unsigned int mp_add(const digit_t* a, const digit_t* b, digit_t* c, const unsigned int nwords)
 { // Multiprecision addition, c = a+b, where lng(a) = lng(b) = nwords. Returns the carry bit.

--- a/pq-crypto/sike_r1/sike_r1_namespace.h
+++ b/pq-crypto/sike_r1/sike_r1_namespace.h
@@ -20,6 +20,8 @@
 #define xDBLADD xDBLADD_r1
 #define swap_points swap_points_r1
 #define LADDER3PT LADDER3PT_r1
+#define xTPL_fast xTPL_fast_r1
+#define xTPLe_fast xTPLe_fast_r1
 #define load64 load64_r1
 #define store64 store64_r1
 #define KeccakF1600_StatePermute KeccakF1600_StatePermute_r1
@@ -39,6 +41,7 @@
 #define mp_subfast mp_subfast_r1
 #define to_fp2mont to_fp2mont_r1
 #define from_fp2mont from_fp2mont_r1
+#define is_felm_zero is_felm_zero_r1
 #define mp_add mp_add_r1
 #define mp_shiftr1 mp_shiftr1_r1
 #define Alice_order Alice_order_r1

--- a/pq-crypto/sike_r3/sikep434r3_ec_isogeny.c
+++ b/pq-crypto/sike_r3/sikep434r3_ec_isogeny.c
@@ -33,11 +33,9 @@ void xDBL(const point_proj_t P, point_proj_t Q, const f2elm_t *A24plus, const f2
  * Output: projective Montgomery x-coordinates Q <- (2^e)*P. */
 void xDBLe(const point_proj_t P, point_proj_t Q, const f2elm_t *A24plus, const f2elm_t *C24, const int e)
 {
-    int i;
-    
     copy_words((const digit_t*)P, (digit_t*)Q, 2*2*S2N_SIKE_P434_R3_NWORDS_FIELD);
 
-    for (i = 0; i < e; i++) {
+    for (int i = 0; i < e; i++) {
         xDBL(Q, Q, A24plus, C24);
     }
 }
@@ -121,11 +119,9 @@ void xTPL(const point_proj_t P, point_proj_t Q, const f2elm_t *A24minus, const f
  * Output: projective Montgomery x-coordinates Q <- (3^e)*P. */
 void xTPLe(const point_proj_t P, point_proj_t Q, const f2elm_t *A24minus, const f2elm_t *A24plus, const int e)
 {
-    int i;
-        
     copy_words((const digit_t*)P, (digit_t*)Q, 2*2*S2N_SIKE_P434_R3_NWORDS_FIELD);
 
-    for (i = 0; i < e; i++) {
+    for (int i = 0; i < e; i++) {
         xTPL(Q, Q, A24minus, A24plus);
     }
 }
@@ -345,4 +341,48 @@ void LADDER3PT(const f2elm_t *xP, const f2elm_t *xQ, const f2elm_t *xPQ, const d
     swap = 0 ^ prevbit;
     mask = 0 - (digit_t)swap;
     swap_points(R, R2, mask);
+}
+
+void xTPL_fast(const point_proj_t P, point_proj_t Q, const f2elm_t *A2)
+{ // Montgomery curve (E: y^2 = x^3 + A*x^2 + x) x-only tripling at a cost of 5M + 6S + 11A.
+  // Input : projective Montgomery x-coordinates P = (X:Z), where x=X/Z and Montgomery curve constant A/2.
+  // Output: projective Montgomery x-coordinates Q = 3*P = (X3:Z3).
+    f2elm_t _t1, _t2, _t3, _t4;
+    f2elm_t *t1=&_t1, *t2=&_t2, *t3=&_t3, *t4=&_t4;
+
+    fp2sqr_mont(&P->X, t1);       // t1 = x^2
+    fp2sqr_mont(&P->Z, t2);       // t2 = z^2
+    fp2add(t1, t2, t3);           // t3 = t1 + t2
+    fp2add(&P->X, &P->Z, t4);       // t4 = x + z
+    fp2sqr_mont(t4, t4);          // t4 = t4^2
+    fp2sub(t4, t3, t4);           // t4 = t4 - t3
+    fp2mul_mont(A2, t4, t4);      // t4 = t4*A2
+    fp2add(t3, t4, t4);           // t4 = t4 + t3
+    fp2sub(t1, t2, t3);           // t3 = t1 - t2
+    fp2sqr_mont(t3, t3);          // t3 = t3^2
+    fp2mul_mont(t1, t4, t1);      // t1 = t1*t4
+    fp2add(t1, t1, t1);           // t1 = 2*t1
+    fp2add(t1, t1, t1);           // t1 = 4*t1
+    fp2sub(t1, t3, t1);           // t1 = t1 - t3
+    fp2sqr_mont(t1, t1);          // t1 = t1^2
+    fp2mul_mont(t2, t4, t2);      // t2 = t2*t4
+    fp2add(t2, t2, t2);           // t2 = 2*t2
+    fp2add(t2, t2, t2);           // t2 = 4*t2
+    fp2sub(t2, t3, t2);           // t2 = t2 - t3
+    fp2sqr_mont(t2, t2);          // t2 = t2^2
+    fp2mul_mont(&P->X, t2, &Q->X);  // x = x*t2
+    fp2mul_mont(&P->Z, t1, &Q->Z);  // z = z*t1
+}
+
+
+void xTPLe_fast(point_proj_t P, point_proj_t Q, const f2elm_t *A2, int e)
+{ // Computes [3^e](X:Z) on Montgomery curve with projective constant via e repeated triplings. e triplings in E costs e*(5M + 6S + 11A)
+  // Input: projective Montgomery x-coordinates P = (X:Z), where x=X/Z, Montgomery curve constant A2 = A/2 and the number of triplings e.
+  // Output: projective Montgomery x-coordinates Q <- [3^e]P.
+
+    copy_words((digit_t*)P, (digit_t*)Q, 2 * 2 * S2N_SIKE_P434_R3_NWORDS_FIELD);
+
+    for (int i = 0; i < e; i++) {
+        xTPL_fast(Q, Q, A2);
+    }
 }

--- a/pq-crypto/sike_r3/sikep434r3_ec_isogeny.h
+++ b/pq-crypto/sike_r3/sikep434r3_ec_isogeny.h
@@ -44,3 +44,9 @@ void j_inv(const f2elm_t *A, const f2elm_t *C, f2elm_t *jinv);
 #define LADDER3PT S2N_SIKE_P434_R3_NAMESPACE(LADDER3PT)
 void LADDER3PT(const f2elm_t *xP, const f2elm_t *xQ, const f2elm_t *xPQ, const digit_t *m,
         const unsigned int AliceOrBob, point_proj_t R, const f2elm_t *A);
+
+#define xTPL_fast S2N_SIKE_P434_R3_NAMESPACE(xTPL_fast)
+void xTPL_fast(const point_proj_t P, point_proj_t Q, const f2elm_t *A2);
+
+#define xTPLe_fast S2N_SIKE_P434_R3_NAMESPACE(xTPLe_fast)
+void xTPLe_fast(point_proj_t P, point_proj_t Q, const f2elm_t *A2, int e);

--- a/pq-crypto/sike_r3/sikep434r3_fpx.h
+++ b/pq-crypto/sike_r3/sikep434r3_fpx.h
@@ -25,6 +25,9 @@ void fp2copy(const f2elm_t *a, f2elm_t *c);
 #define fp2div2 S2N_SIKE_P434_R3_NAMESPACE(fp2div2)
 void fp2div2(const f2elm_t *a, f2elm_t *c);
 
+#define fp2correction S2N_SIKE_P434_R3_NAMESPACE(fp2correction)
+void fp2correction(f2elm_t *a);
+
 #define mp_add S2N_SIKE_P434_R3_NAMESPACE(mp_add)
 unsigned int mp_add(const digit_t* a, const digit_t* b, digit_t* c, const unsigned int nwords);
 
@@ -39,6 +42,9 @@ void fp2inv_mont(f2elm_t *a);
 
 #define mp_shiftr1 S2N_SIKE_P434_R3_NAMESPACE(mp_shiftr1)
 void mp_shiftr1(digit_t* x, const unsigned int nwords);
+
+#define is_felm_zero S2N_SIKE_P434_R3_NAMESPACE(is_felm_zero)
+unsigned int is_felm_zero(const felm_t x);
 
 #define decode_to_digits S2N_SIKE_P434_R3_NAMESPACE(decode_to_digits)
 void decode_to_digits(const unsigned char* x, digit_t* dec, int nbytes, int ndigits);

--- a/pq-crypto/sike_r3/sikep434r3_kem.c
+++ b/pq-crypto/sike_r3/sikep434r3_kem.c
@@ -81,9 +81,13 @@ int s2n_sike_p434_r3_crypto_kem_dec(unsigned char *ss, const unsigned char *ct, 
     unsigned char h_[S2N_SIKE_P434_R3_MSG_BYTES];
     unsigned char c0_[S2N_SIKE_P434_R3_PUBLIC_KEY_BYTES];
     unsigned char temp[S2N_SIKE_P434_R3_CIPHERTEXT_BYTES+S2N_SIKE_P434_R3_MSG_BYTES];
+    bool dont_copy = 1;
 
     /* Decrypt */
-    EphemeralSecretAgreement_B(sk + S2N_SIKE_P434_R3_MSG_BYTES, ct, jinvariant_);
+    if (!(EphemeralSecretAgreement_B(sk + S2N_SIKE_P434_R3_MSG_BYTES, ct, jinvariant_) == 0)) {
+        goto S2N_SIKE_P434_R3_HASHING;
+    }
+
     shake256(h_, S2N_SIKE_P434_R3_MSG_BYTES, jinvariant_, S2N_SIKE_P434_R3_FP2_ENCODED_BYTES);
     for (int i = 0; i < S2N_SIKE_P434_R3_MSG_BYTES; i++) {
         temp[i] = ct[i + S2N_SIKE_P434_R3_PUBLIC_KEY_BYTES] ^ h_[i];
@@ -103,7 +107,8 @@ int s2n_sike_p434_r3_crypto_kem_dec(unsigned char *ss, const unsigned char *ct, 
      *
      * If c0_ and ct are equal, then decaps succeeded and we skip the overwrite and output
      * the actual shared secret: ss = H(m||ct) (dont_copy = true). */
-    bool dont_copy = s2n_constant_time_equals(c0_, ct, S2N_SIKE_P434_R3_PUBLIC_KEY_BYTES);
+    dont_copy = s2n_constant_time_equals(c0_, ct, S2N_SIKE_P434_R3_PUBLIC_KEY_BYTES);
+S2N_SIKE_P434_R3_HASHING:
     POSIX_GUARD(s2n_constant_time_copy_or_dont(temp, sk, S2N_SIKE_P434_R3_MSG_BYTES, dont_copy));
     memcpy(&temp[S2N_SIKE_P434_R3_MSG_BYTES], ct, S2N_SIKE_P434_R3_CIPHERTEXT_BYTES);
     shake256(ss, S2N_SIKE_P434_R3_SHARED_SECRET_BYTES, temp, S2N_SIKE_P434_R3_CIPHERTEXT_BYTES+S2N_SIKE_P434_R3_MSG_BYTES);

--- a/pq-crypto/sike_r3/sikep434r3_sidh.c
+++ b/pq-crypto/sike_r3/sikep434r3_sidh.c
@@ -245,15 +245,57 @@ int EphemeralSecretAgreement_A(const unsigned char* PrivateKeyA, const unsigned 
     return 0;
 }
 
+int sike_p434_r3_publickey_validation(const f2elm_t *PKB, const f2elm_t *A)
+{ // Public key validation
+    point_proj_t P = { 0 }, Q = { 0 };
+    f2elm_t _A2={0}, _tmp1={0}, _tmp2={0};
+    f2elm_t *A2=&_A2, *tmp1=&_tmp1, *tmp2=&_tmp2;
+
+    // Verify that P and Q generate E_A[3^e_3] by checking that [3^(e_3-1)]P != [+-3^(e_3-1)]Q
+    fp2div2(A, A2);
+    fp2copy(&PKB[0], &P->X);
+    fpcopy((const digit_t*)&Montgomery_one, (digit_t*)&P->Z);
+    fp2copy(&PKB[1], &Q->X);
+    fpcopy((const digit_t*)&Montgomery_one, (digit_t*)&Q->Z);
+
+    xTPLe_fast(P, P, A2, S2N_SIKE_P434_R3_MAX_BOB - 1);
+    xTPLe_fast(Q, Q, A2, S2N_SIKE_P434_R3_MAX_BOB - 1);
+    fp2correction(&P->Z);
+    fp2correction(&Q->Z);
+
+    if ((is_felm_zero((P->Z.e)[0]) && is_felm_zero((P->Z.e)[1])) || (is_felm_zero((Q->Z.e)[0]) && is_felm_zero((Q->Z.e)[1]))) {
+        return 1;
+    }
+
+    fp2mul_mont(&P->X, &Q->Z, tmp1);
+    fp2mul_mont(&P->Z, &Q->X, tmp2);
+    fp2correction(tmp1);
+    fp2correction(tmp2);
+
+    if (memcmp((uint8_t*)tmp1, (uint8_t*)tmp2, S2N_SIKE_P434_R3_FP2_ENCODED_BYTES) == 0) {
+        return 1;
+    }
+
+    // Check that Ord(P) = Ord(Q) = 3^(e_3)
+    xTPL_fast(P, P, A2);
+    xTPL_fast(Q, Q, A2);
+    fp2correction(&P->Z);
+    fp2correction(&Q->Z);
+
+    if (!is_felm_zero((P->Z.e)[0]) || !is_felm_zero((P->Z.e)[1]) || !is_felm_zero((Q->Z.e)[0]) || !is_felm_zero((Q->Z.e)[1])) {
+        return 1;
+    }
+
+    return 0;
+}
+
 /* Bob's ephemeral shared secret computation
  * It produces a shared secret key SharedSecretB using his secret key PrivateKeyB and Alice's public key PublicKeyA
  * Inputs: Bob's PrivateKeyB is an integer in the range [0, 2^Floor(Log(2,oB)) - 1].
  *     Alice's PublicKeyA consists of 3 elements in GF(p^2) encoded by removing leading 0 bytes.
  * Output: a shared secret SharedSecretB that consists of one element in GF(p^2) encoded
  *     by removing leading 0 bytes.   */
-int EphemeralSecretAgreement_B(const unsigned char* PrivateKeyB, const unsigned char* PublicKeyA,
-        unsigned char* SharedSecretB)
-{
+int EphemeralSecretAgreement_B(const unsigned char* PrivateKeyB, const unsigned char* PublicKeyA, unsigned char* SharedSecretB) {
     point_proj_t R, pts[S2N_SIKE_P434_R3_MAX_INT_POINTS_BOB];
     f2elm_t coeff[3], PKB[3], _jinv;
     f2elm_t _A24plus = {0}, _A24minus = {0}, _A = {0};
@@ -271,6 +313,11 @@ int EphemeralSecretAgreement_B(const unsigned char* PrivateKeyB, const unsigned 
     mp_add((const digit_t*)&Montgomery_one, (const digit_t*)&Montgomery_one, A24minus->e[0], S2N_SIKE_P434_R3_NWORDS_FIELD);
     mp2_add(A, A24minus, A24plus);
     mp2_sub_p2(A, A24minus, A24minus);
+
+    // Always perform public key validation before using peer's public key
+    if (sike_p434_r3_publickey_validation(PKB, A) == 1) {
+        return 1;
+    }
 
     /* Retrieve kernel point */
     decode_to_digits(PrivateKeyB, SecretKeyB, S2N_SIKE_P434_R3_SECRETKEY_B_BYTES, S2N_SIKE_P434_R3_NWORDS_ORDER);

--- a/tests/cbmc/include/README.md
+++ b/tests/cbmc/include/README.md
@@ -1,1 +1,6 @@
-../templates/template-for-repository/include/README.md
+CBMC proof include files
+========================
+
+This directory contains include files written for CBMC proof.  It is
+common to write some code to model aspects of the system under test,
+and the header files for this code go here.

--- a/tests/cbmc/proofs/Makefile-project-defines
+++ b/tests/cbmc/proofs/Makefile-project-defines
@@ -1,8 +1,6 @@
 # -*- mode: makefile -*-
 # The first line sets the emacs major mode to Makefile
 
-# Copyright Amazon.com, Inc. or its affiliates. All Rights Reserved.
-# SPDX-License-Identifier: Apache-2.0
 
 ################################################################
 # Use this file to give project-specific definitions of the command

--- a/tests/cbmc/proofs/Makefile-project-defines.backup
+++ b/tests/cbmc/proofs/Makefile-project-defines.backup
@@ -1,0 +1,54 @@
+# -*- mode: makefile -*-
+# The first line sets the emacs major mode to Makefile
+
+# Copyright Amazon.com, Inc. or its affiliates. All Rights Reserved.
+# SPDX-License-Identifier: Apache-2.0
+
+################################################################
+# Use this file to give project-specific definitions of the command
+# line arguments to pass to CBMC tools like goto-cc to build the goto
+# binaries and cbmc to do the property and coverage checking.
+#
+# Use this file to override most default definitions of variables in
+# Makefile.common.
+################################################################
+
+# Flags to pass to goto-cc for compilation (typically those passed to gcc -c)
+# COMPILE_FLAGS =
+
+# Flags to pass to goto-cc for linking (typically those passed to gcc)
+# LINK_FLAGS =
+
+# Preprocessor include paths -I...
+INCLUDES += -I$(CBMC_ROOT)/include
+INCLUDES += -I$(CBMC_ROOT)/aws-verification-model-for-libcrypto/include
+INCLUDES += -I$(SRCDIR)
+INCLUDES += -I$(SRCDIR)/api
+INCLUDES += -I$(SRCDIR)/crypto
+
+# OpenSSL Model Source
+OPENSSL_SOURCE = $(CBMC_ROOT)/aws-verification-model-for-libcrypto/source
+
+# Preprocessor definitions -D...
+
+# Whether a proof needs these checks should be decided on a proof by proof basis.
+# Checks can be enabled by setting AWS_DEEP_CHECKS to 1 in the makefile
+# of the proof that requires them
+AWS_DEEP_CHECKS ?= 0
+DEFINES += -DAWS_DEEP_CHECKS=$(AWS_DEEP_CHECKS)
+
+# Extra CBMC flags not enabled by Makefile.common
+# CHECKFLAGS += --enum-range-check
+CHECKFLAGS += --pointer-primitive-check
+
+################################################################
+# Remove function bodies that are not used in the proofs.
+# Removing the function from the goto program helps CBMC's
+# function pointer analysis
+
+# We override abort() to be assert(0)
+PROOF_SOURCES += $(PROOF_STUB)/abort_override_assert_false.c
+REMOVE_FUNCTION_BODY += abort
+
+# Useful for setting unwind limits to one more than some value.
+addone = $(shell echo $$(( $(1) + 1)))

--- a/tests/cbmc/proofs/Makefile-project-targets
+++ b/tests/cbmc/proofs/Makefile-project-targets
@@ -1,8 +1,6 @@
 # -*- mode: makefile -*-
 # The first line sets the emacs major mode to Makefile
 
-# Copyright Amazon.com, Inc. or its affiliates. All Rights Reserved.
-# SPDX-License-Identifier: Apache-2.0
 
 ################################################################
 # Use this file to give project-specific targets, including targets

--- a/tests/cbmc/proofs/Makefile-project-targets.backup
+++ b/tests/cbmc/proofs/Makefile-project-targets.backup
@@ -1,0 +1,10 @@
+# -*- mode: makefile -*-
+# The first line sets the emacs major mode to Makefile
+
+# Copyright Amazon.com, Inc. or its affiliates. All Rights Reserved.
+# SPDX-License-Identifier: Apache-2.0
+
+################################################################
+# Use this file to give project-specific targets, including targets
+# that may depend on targets defined in Makefile.common.
+################################################################

--- a/tests/cbmc/proofs/Makefile-project-testing
+++ b/tests/cbmc/proofs/Makefile-project-testing
@@ -1,8 +1,6 @@
 # -*- mode: makefile -*-
 # The first line sets the emacs major mode to Makefile
 
-# Copyright Amazon.com, Inc. or its affiliates. All Rights Reserved.
-# SPDX-License-Identifier: Apache-2.0
 
 ################################################################
 # Use this file to define project-specific targets and definitions for

--- a/tests/cbmc/proofs/Makefile-project-testing.backup
+++ b/tests/cbmc/proofs/Makefile-project-testing.backup
@@ -1,0 +1,11 @@
+# -*- mode: makefile -*-
+# The first line sets the emacs major mode to Makefile
+
+# Copyright Amazon.com, Inc. or its affiliates. All Rights Reserved.
+# SPDX-License-Identifier: Apache-2.0
+
+################################################################
+# Use this file to define project-specific targets and definitions for
+# unit testing or continuous integration that may depend on targets
+# defined in Makefile.common
+################################################################

--- a/tests/cbmc/proofs/Makefile.common
+++ b/tests/cbmc/proofs/Makefile.common
@@ -1,1 +1,918 @@
-../templates/template-for-repository/proofs/Makefile.common
+# -*- mode: makefile -*-
+# The first line sets the emacs major mode to Makefile
+
+# Copyright Amazon.com, Inc. or its affiliates. All Rights Reserved.
+# SPDX-License-Identifier: MIT-0
+
+CBMC_STARTER_KIT_VERSION = CBMC starter kit 2.4
+
+################################################################
+# The CBMC Starter Kit depends on the files Makefile.common and
+# run-cbmc-proofs.py.  They are installed by the setup script
+# cbmc-starter-kit-setup and updated to the latest version by the
+# update script cbmc-starter-kit-update.  For more information about
+# the starter kit and these files and these scripts, see
+# https://model-checking.github.io/cbmc-starter-kit
+#
+# Makefile.common implements what we consider to be some best
+# practices for using cbmc for software verification.
+#
+# Section I gives default values for a large number of Makefile
+# variables that control
+#   * how your code is built (include paths, etc),
+#   * what program transformations are applied to your code (loop
+#     unwinding, etc), and
+#   * what properties cbmc checks for in your code (memory safety, etc).
+#
+# These variables are defined below with definitions of the form
+#   VARIABLE ?= DEFAULT_VALUE
+# meaning VARIABLE is set to DEFAULT_VALUE if VARIABLE has not already
+# been given a value.
+#
+# For your project, you can override these default values with
+# project-specific definitions in Makefile-project-defines.
+#
+# For any individual proof, you can override these default values and
+# project-specific values with proof-specific definitions in the
+# Makefile for your proof.
+#
+# The definitions in the proof Makefile override definitions in the
+# project Makefile-project-defines which override definitions in this
+# Makefile.common.
+#
+# Section II uses the values defined in Section I to build your code, run
+# your proof, and build a report of your results.  You should not need
+# to modify or override anything in Section II, but you may want to
+# read it to understand how the values defined in Section I control
+# things.
+#
+# To use Makefile.common, set variables as described above as needed,
+# and then for each proof,
+#
+#   * Create a subdirectory <DIR>.
+#   * Write a proof harness (a function) with the name <HARNESS_ENTRY>
+#     in a file with the name <DIR>/<HARNESS_FILE>.c
+#   * Write a makefile with the name <DIR>/Makefile that looks
+#     something like
+#
+#     HARNESS_FILE=<HARNESS_FILE>
+#     HARNESS_ENTRY=<HARNESS_ENTRY>
+#     PROOF_UID=<PROOF_UID>
+#
+#     PROJECT_SOURCES += $(SRCDIR)/libraries/api_1.c
+#     PROJECT_SOURCES += $(SRCDIR)/libraries/api_2.c
+#
+#     PROOF_SOURCES += $(PROOFDIR)/harness.c
+#     PROOF_SOURCES += $(SRCDIR)/cbmc/proofs/stub_a.c
+#     PROOF_SOURCES += $(SRCDIR)/cbmc/proofs/stub_b.c
+#
+#     UNWINDSET += foo.0:3
+#     UNWINDSET += bar.1:6
+#
+#     REMOVE_FUNCTION_BODY += api_stub_a
+#     REMOVE_FUNCTION_BODY += api_stub_b
+#
+#     DEFINES = -DDEBUG=0
+#
+#     include ../Makefile.common
+#
+#   * Change directory to <DIR> and run make
+#
+# The proof setup script cbmc-starter-kit-setup-proof from the CBMC
+# Starter Kit will do most of this for, creating a directory and
+# writing a basic Makefile and proof harness into it that you can edit
+# as described above.
+#
+# Warning: If you get results that are hard to explain, consider
+# running "make clean" or "make veryclean" before "make" if you get
+# results that are hard to explain.  Dependency handling in this
+# Makefile.common may not be perfect.
+
+SHELL=/bin/bash
+
+default: report
+
+################################################################
+################################################################
+## Section I: This section gives common variable definitions.
+##
+## Override these definitions in Makefile-project-defines or
+## your proof Makefile.
+##
+## Remember that Makefile.common and Makefile-project-defines are
+## included into the proof Makefile in your proof directory, so all
+## relative pathnames defined there should be relative to your proof
+## directory.
+
+################################################################
+# Define the layout of the source tree and the proof subtree
+#
+# Generally speaking,
+#
+#   SRCDIR = the root of the repository
+#   CBMC_ROOT = /srcdir/cbmc
+#   PROOF_ROOT = /srcdir/cbmc/proofs
+#   PROOF_SOURCE = /srcdir/cbmc/sources
+#   PROOF_INCLUDE = /srcdir/cbmc/include
+#   PROOF_STUB = /srcdir/cbmc/stubs
+#   PROOFDIR = the directory containing the Makefile for your proof
+#
+# The path /srcdir/cbmc used in the example above is determined by the
+# setup script cbmc-starter-kit-setup.  Projects usually create a cbmc
+# directory somewhere in the source tree, and run the setup script in
+# that directory.  The value of CBMC_ROOT becomes the absolute path to
+# that directory.
+#
+# The location of that cbmc directory in the source tree affects the
+# definition of SRCDIR, which is defined in terms of the relative path
+# from a proof directory to the repository root.  The definition is
+# usually determined by the setup script cbmc-starter-kit-setup and
+# written to Makefile-template-defines, but you can override it for a
+# project in Makefile-project-defines and for a specific proof in the
+# Makefile for the proof.
+
+# Absolute path to the directory containing this Makefile.common
+# See https://ftp.gnu.org/old-gnu/Manuals/make-3.80/html_node/make_17.html
+#
+# Note: We compute the absolute paths to the makefiles in MAKEFILE_LIST
+# before we filter the list of makefiles for %/Makefile.common.
+# Otherwise an invocation of the form "make -f Makefile.common" will set
+# MAKEFILE_LIST to "Makefile.common" which will fail to match the
+# pattern %/Makefile.common.
+#
+MAKEFILE_PATHS = $(foreach makefile,$(MAKEFILE_LIST),$(abspath $(makefile)))
+PROOF_ROOT = $(dir $(filter %/Makefile.common,$(MAKEFILE_PATHS)))
+
+CBMC_ROOT = $(shell dirname $(PROOF_ROOT))
+PROOF_SOURCE = $(CBMC_ROOT)/sources
+PROOF_INCLUDE = $(CBMC_ROOT)/include
+PROOF_STUB = $(CBMC_ROOT)/stubs
+
+# Project-specific definitions to override default definitions below
+#   * Makefile-project-defines will never be overwritten
+#   * Makefile-template-defines may be overwritten when the starter
+#     kit is updated
+sinclude $(PROOF_ROOT)/Makefile-project-defines
+sinclude $(PROOF_ROOT)/Makefile-template-defines
+
+# SRCDIR is the path to the root of the source tree
+# This is a default definition that is frequently overridden in
+# another Makefile, see the discussion of SRCDIR above.
+SRCDIR ?= $(abspath ../..)
+
+# PROOFDIR is the path to the directory containing the proof harness
+PROOFDIR ?= $(abspath .)
+
+################################################################
+# Define how to run CBMC
+
+# Do property checking with the external SAT solver given by
+# EXTERNAL_SAT_SOLVER.  Do coverage checking with the default solver,
+# since coverage checking requires the use of an incremental solver.
+# The EXTERNAL_SAT_SOLVER variable is typically set (if it is at all)
+# as an environment variable or as a makefile variable in
+# Makefile-project-defines.
+#
+# For a particular proof, if the default solver is faster, do property
+# checking with the default solver by including this definition in the
+# proof Makefile:
+#         USE_EXTERNAL_SAT_SOLVER =
+#
+ifneq ($(strip $(EXTERNAL_SAT_SOLVER)),)
+   USE_EXTERNAL_SAT_SOLVER ?= --external-sat-solver $(EXTERNAL_SAT_SOLVER)
+endif
+CHECKFLAGS += $(USE_EXTERNAL_SAT_SOLVER)
+
+# Job pools
+# For version of Litani that are new enough (where `litani print-capabilities`
+# prints "pools"), proofs for which `EXPENSIVE = true` is set can be added to a
+# "job pool" that restricts how many expensive proofs are run at a time. All
+# other proofs will be built in parallel as usual.
+#
+# In more detail: all compilation, instrumentation, and report jobs are run with
+# full parallelism as usual, even for expensive proofs. The CBMC jobs for
+# non-expensive proofs are also run in parallel. The only difference is that the
+# CBMC safety checks and coverage checks for expensive proofs are run with a
+# restricted parallelism level. At any one time, only N of these jobs are run at
+# once, amongst all the proofs.
+#
+# To configure N, Litani needs to be initialized with a pool called "expensive".
+# For example, to only run two CBMC safety/coverage jobs at a time from amongst
+# all the proofs, you would initialize litani like
+#         litani init --pools expensive:2
+# The run-cbmc-proofs.py script takes care of this initialization through the
+# --expensive-jobs-parallelism flag.
+#
+# To enable this feature, set
+# the ENABLE_POOLS variable when running Make, like
+#         `make ENABLE_POOLS=true report`
+# The run-cbmc-proofs.py script takes care of this through the
+# --restrict-expensive-jobs flag.
+
+ifeq ($(strip $(ENABLE_POOLS)),)
+  POOL =
+else ifeq ($(strip $(EXPENSIVE)),)
+  POOL =
+else
+  POOL = --pool expensive
+endif
+
+# Similar to the pool feature above. If Litani is new enough, enable
+# profiling CBMC's memory use.
+ifeq ($(strip $(ENABLE_MEMORY_PROFILING)),)
+  MEMORY_PROFILING =
+else
+  MEMORY_PROFILING = --profile-memory
+endif
+
+# Property checking flags
+#
+# Each variable below controls a specific property checking flag
+# within CBMC. If desired, a property flag can be disabled within
+# a particular proof by nulling the corresponding variable. For
+# instance, the following line:
+#
+#     CHECK_FLAG_POINTER_CHECK =
+#
+# would disable the --pointer-check CBMC flag within:
+#   * an entire project when added to Makefile-project-defines
+#   * a specific proof when added to the harness Makefile
+
+CBMC_FLAG_MALLOC_MAY_FAIL ?= --malloc-may-fail
+CBMC_FLAG_MALLOC_FAIL_NULL ?= --malloc-fail-null
+CBMC_FLAG_BOUNDS_CHECK ?= --bounds-check
+CBMC_FLAG_CONVERSION_CHECK ?= --conversion-check
+CBMC_FLAG_DIV_BY_ZERO_CHECK ?= --div-by-zero-check
+CBMC_FLAG_FLOAT_OVERFLOW_CHECK ?= --float-overflow-check
+CBMC_FLAG_NAN_CHECK ?= --nan-check
+CBMC_FLAG_POINTER_CHECK ?= --pointer-check
+CBMC_FLAG_POINTER_OVERFLOW_CHECK ?= --pointer-overflow-check
+CBMC_FLAG_POINTER_PRIMITIVE_CHECK ?= --pointer-primitive-check
+CBMC_FLAG_SIGNED_OVERFLOW_CHECK ?= --signed-overflow-check
+CBMC_FLAG_UNDEFINED_SHIFT_CHECK ?= --undefined-shift-check
+CBMC_FLAG_UNSIGNED_OVERFLOW_CHECK ?= --unsigned-overflow-check
+CBMC_FLAG_UNWINDING_ASSERTIONS ?= --unwinding-assertions
+CBMC_FLAG_UNWIND ?= --unwind 1
+CBMC_FLAG_FLUSH ?= --flush
+
+# CBMC flags used for property checking and coverage checking
+
+CBMCFLAGS += $(CBMC_FLAG_UNWIND) $(CBMC_UNWINDSET) $(CBMC_FLAG_FLUSH)
+
+# CBMC flags used for property checking
+
+CHECKFLAGS += $(CBMC_FLAG_MALLOC_MAY_FAIL)
+CHECKFLAGS += $(CBMC_FLAG_MALLOC_FAIL_NULL)
+CHECKFLAGS += $(CBMC_FLAG_BOUNDS_CHECK)
+CHECKFLAGS += $(CBMC_FLAG_CONVERSION_CHECK)
+CHECKFLAGS += $(CBMC_FLAG_DIV_BY_ZERO_CHECK)
+CHECKFLAGS += $(CBMC_FLAG_FLOAT_OVERFLOW_CHECK)
+CHECKFLAGS += $(CBMC_FLAG_NAN_CHECK)
+CHECKFLAGS += $(CBMC_FLAG_POINTER_CHECK)
+CHECKFLAGS += $(CBMC_FLAG_POINTER_OVERFLOW_CHECK)
+CHECKFLAGS += $(CBMC_FLAG_POINTER_PRIMITIVE_CHECK)
+CHECKFLAGS += $(CBMC_FLAG_SIGNED_OVERFLOW_CHECK)
+CHECKFLAGS += $(CBMC_FLAG_UNDEFINED_SHIFT_CHECK)
+CHECKFLAGS += $(CBMC_FLAG_UNSIGNED_OVERFLOW_CHECK)
+CHECKFLAGS += $(CBMC_FLAG_UNWINDING_ASSERTIONS)
+
+# CBMC flags used for coverage checking
+
+COVERFLAGS += $(CBMC_FLAG_MALLOC_MAY_FAIL)
+COVERFLAGS += $(CBMC_FLAG_MALLOC_FAIL_NULL)
+
+# Additional CBMC flag to CBMC control verbosity.
+#
+# Meaningful values are
+# 0 none
+# 1 only errors
+# 2 + warnings
+# 4 + results
+# 6 + status/phase information
+# 8 + statistical information
+# 9 + progress information
+# 10 + debug info
+#
+# Uncomment the following line or set in Makefile-project-defines
+# CBMC_VERBOSITY ?= --verbosity 4
+
+# Additional CBMC flag to control how CBMC treats static variables.
+#
+# NONDET_STATIC is a list of flags of the form --nondet-static
+# and --nondet-static-exclude VAR.  The --nondet-static flag causes
+# CBMC to initialize static variables with unconstrained value
+# (ignoring initializers and default zero-initialization).  The
+# --nondet-static-exclude VAR excludes VAR for the variables
+# initialized with unconstrained values.
+NONDET_STATIC ?=
+
+# Flags to pass to goto-cc for compilation and linking
+COMPILE_FLAGS ?= -Wall
+LINK_FLAGS ?= -Wall
+
+# Preprocessor include paths -I...
+INCLUDES ?=
+
+# Preprocessor definitions -D...
+DEFINES ?=
+
+# CBMC object model
+#
+# CBMC_OBJECT_BITS is the number of bits in a pointer CBMC uses for
+# the id of the object to which a pointer is pointing.  CBMC uses 8
+# bits for the object id by default. The remaining bits in the pointer
+# are used for offset into the object.  This limits the size of the
+# objects that CBMC can model.  This Makefile defines this bound on
+# object size to be CBMC_MAX_OBJECT_SIZE.  You are likely to get
+# unexpected results if you try to malloc an object larger than this
+# bound.
+CBMC_OBJECT_BITS ?= 8
+
+# CBMC loop unwinding (Normally set in the proof Makefile)
+#
+# UNWINDSET is a list of pairs of the form foo.1:4 meaning that
+# CBMC should unwind loop 1 in function foo no more than 4 times.
+# For historical reasons, the number 4 is one more than the number
+# of times CBMC actually unwinds the loop.
+UNWINDSET ?=
+
+# CBMC early loop unwinding (Normally set in the proof Makefile)
+#
+# Most users can ignore this variable.
+#
+# This variable exists to support the use of loop and function
+# contracts, two features under development for CBMC.  Checking the
+# assigns clause for function contracts and loop invariants currently
+# assumes loop-free bodies for loops and functions with contracts
+# (possibly after replacing nested loops with their own loop
+# contracts).  To satisfy this requirement, it may be necessary to
+# unwind some loops before the function contract and loop invariant
+# transformations are applied to the goto program.  This variable
+# EARLY_UNWINDSET is identical to UNWINDSET, and we assume that the
+# loops mentioned in EARLY_UNWINDSET and UNWINDSET are disjoint.
+EARLY_UNWINDSET ?=
+
+# CBMC function removal (Normally set set in the proof Makefile)
+#
+# REMOVE_FUNCTION_BODY is a list of function names.  CBMC will "undefine"
+# the function, and CBMC will treat the function as having no side effects
+# and returning an unconstrained value of the appropriate return type.
+# The list should include the names of functions being stubbed out.
+REMOVE_FUNCTION_BODY ?=
+
+# CBMC function pointer restriction (Normally set in the proof Makefile)
+#
+# RESTRICT_FUNCTION_POINTER is a list of function pointer restriction
+# instructions of the form:
+#
+#    <fun_id>.function_pointer_call.<N>/<fun_id>[,<fun_id>]*
+#
+# The function pointer call number <N> in the specified function gets
+# rewritten to a case switch over a finite list of functions.
+# If some possible target functions are omitted from the list a counter
+# example trace will be found by CBMC, i.e. the transformation is sound.
+# If the target functions are file-local symbols, then mangled names must
+# be used.
+RESTRICT_FUNCTION_POINTER ?=
+
+# The project source files (Normally set set in the proof Makefile)
+#
+# PROJECT_SOURCES is the list of project source files to compile,
+# including the source file defining the function under test.
+PROJECT_SOURCES ?=
+
+# The proof source files (Normally set in the proof Makefile)
+#
+# PROOF_SOURCES is the list of proof source files to compile, including
+# the proof harness, and including any function stubs being used.
+PROOF_SOURCES ?=
+
+# The number of seconds that CBMC should be allowed to run for before
+# being forcefully terminated. Currently, this is set to be less than
+# the time limit for a CodeBuild job, which is eight hours. If a proof
+# run takes longer than the time limit of the CI environment, the
+# environment will halt the proof run without updating the Litani
+# report, making the proof run appear to "hang".
+CBMC_TIMEOUT ?= 21600
+
+# Proof writers could add function contracts in their source code.
+# These contracts are ignored by default, but may be enabled in two distinct
+# contexts using the following two variables:
+# 1. To check whether one or more function contracts are sound with respect to
+#    the function implementation, CHECK_FUNCTION_CONTRACTS should be a list of
+#    function names.
+# 2. To replace calls to certain functions with their correspondent function
+#    contracts, USE_FUNCTION_CONTRACTS should be a list of function names.
+#    One must check separately whether a function contract is sound before
+#    replacing it in calling contexts.
+CHECK_FUNCTION_CONTRACTS ?=
+CBMC_CHECK_FUNCTION_CONTRACTS := $(patsubst %,--enforce-contract %, $(CHECK_FUNCTION_CONTRACTS))
+
+USE_FUNCTION_CONTRACTS ?=
+CBMC_USE_FUNCTION_CONTRACTS := $(patsubst %,--replace-call-with-contract %, $(USE_FUNCTION_CONTRACTS))
+
+# Similarly, proof writers could also add loop contracts in their source code
+# to obtain unbounded correctness proofs. Unlike function contracts, loop
+# contracts are not reusable and thus are checked and used simultaneously.
+# These contracts are also ignored by default, but may be enabled by setting
+# the APPLY_LOOP_CONTRACTS variable to 1.
+APPLY_LOOP_CONTRACTS ?= 0
+ifeq ($(APPLY_LOOP_CONTRACTS),1)
+  CBMC_APPLY_LOOP_CONTRACTS ?= --apply-loop-contracts
+endif
+
+# Silence makefile output (eg, long litani commands) unless VERBOSE is set.
+ifndef VERBOSE
+    MAKEFLAGS := $(MAKEFLAGS) -s
+endif
+
+################################################################
+################################################################
+## Section II: This section defines the process of running a proof
+##
+## There should be no reason to edit anything below this line.
+
+################################################################
+# Paths
+
+CBMC ?= cbmc
+GOTO_ANALYZER ?= goto-analyzer
+GOTO_CC ?= goto-cc
+GOTO_INSTRUMENT ?= goto-instrument
+VIEWER ?= cbmc-viewer
+MAKE_SOURCE ?= make-source
+VIEWER2 ?= cbmc-viewer
+CMAKE ?= cmake
+
+GOTODIR ?= $(PROOFDIR)/gotos
+LOGDIR ?= $(PROOFDIR)/logs
+
+PROJECT ?= project
+PROOF ?= proof
+
+HARNESS_GOTO ?= $(GOTODIR)/$(HARNESS_FILE)
+PROJECT_GOTO ?= $(GOTODIR)/$(PROJECT)
+PROOF_GOTO ?= $(GOTODIR)/$(PROOF)
+
+################################################################
+# Useful macros for values that are hard to reference
+SPACE :=$() $()
+COMMA :=,
+
+################################################################
+# Set C compiler defines
+
+CBMCFLAGS += --object-bits $(CBMC_OBJECT_BITS)
+COMPILE_FLAGS += --object-bits $(CBMC_OBJECT_BITS)
+
+DEFINES += -DCBMC=1
+DEFINES += -DCBMC_OBJECT_BITS=$(CBMC_OBJECT_BITS)
+DEFINES += -DCBMC_MAX_OBJECT_SIZE="(SIZE_MAX>>(CBMC_OBJECT_BITS+1))"
+
+# CI currently assumes cbmc invocation has at most one --unwindset
+ifdef UNWINDSET
+  ifneq ($(strip $(UNWINDSET)),"")
+    CBMC_UNWINDSET := --unwindset $(subst $(SPACE),$(COMMA),$(strip $(UNWINDSET)))
+  endif
+endif
+ifdef EARLY_UNWINDSET
+  ifneq ($(strip $(EARLY_UNWINDSET)),"")
+    CBMC_EARLY_UNWINDSET := --unwindset $(subst $(SPACE),$(COMMA),$(strip $(EARLY_UNWINDSET)))
+  endif
+endif
+
+CBMC_REMOVE_FUNCTION_BODY := $(patsubst %,--remove-function-body %, $(REMOVE_FUNCTION_BODY))
+CBMC_RESTRICT_FUNCTION_POINTER := $(patsubst %,--restrict-function-pointer %, $(RESTRICT_FUNCTION_POINTER))
+
+################################################################
+# Build targets that make the relevant .goto files
+
+# Compile project sources
+$(PROJECT_GOTO)1.goto: $(PROJECT_SOURCES)
+	$(LITANI) add-job \
+	  --command \
+	    '$(GOTO_CC) $(CBMC_VERBOSITY) --export-file-local-symbols $(COMPILE_FLAGS) $(INCLUDES) $(DEFINES) $^ -o $@' \
+	  --inputs $^ \
+	  --outputs $@ \
+	  --stdout-file $(LOGDIR)/project_sources-log.txt \
+	  --pipeline-name "$(PROOF_UID)" \
+	  --ci-stage build \
+	  --description "$(PROOF_UID): building project binary"
+
+# Compile proof sources
+$(PROOF_GOTO)1.goto: $(PROOF_SOURCES)
+	$(LITANI) add-job \
+	  --command \
+	    '$(GOTO_CC) $(CBMC_VERBOSITY) --export-file-local-symbols $(COMPILE_FLAGS) $(INCLUDES) $(DEFINES) $^ -o $@' \
+	  --inputs $^ \
+	  --outputs $@ \
+	  --stdout-file $(LOGDIR)/proof_sources-log.txt \
+	  --pipeline-name "$(PROOF_UID)" \
+	  --ci-stage build \
+	  --description "$(PROOF_UID): building proof binary"
+
+# Remove function bodies from project sources
+$(PROJECT_GOTO)2.goto: $(PROJECT_GOTO)1.goto
+	$(LITANI) add-job \
+	  --command \
+	    '$(GOTO_INSTRUMENT) $(CBMC_VERBOSITY) $(CBMC_REMOVE_FUNCTION_BODY) $^ $@' \
+	  --inputs $^ \
+	  --outputs $@ \
+	  --stdout-file $(LOGDIR)/remove_function_body-log.txt \
+	  --pipeline-name "$(PROOF_UID)" \
+	  --ci-stage build \
+	  --description "$(PROOF_UID): removing function bodies from project sources"
+
+# Link project and proof sources into the proof harness
+$(HARNESS_GOTO)1.goto: $(PROOF_GOTO)1.goto $(PROJECT_GOTO)2.goto
+	$(LITANI) add-job \
+	  --command '$(GOTO_CC) $(CBMC_VERBOSITY) --function $(HARNESS_ENTRY) $^ $(LINK_FLAGS) -o $@' \
+	  --inputs $^ \
+	  --outputs $@ \
+	  --stdout-file $(LOGDIR)/link_proof_project-log.txt \
+	  --pipeline-name "$(PROOF_UID)" \
+	  --ci-stage build \
+	  --description "$(PROOF_UID): linking project to proof"
+
+# Restrict function pointers
+$(HARNESS_GOTO)2.goto: $(HARNESS_GOTO)1.goto
+	$(LITANI) add-job \
+	  --command \
+	    '$(GOTO_INSTRUMENT) $(CBMC_VERBOSITY) $(CBMC_RESTRICT_FUNCTION_POINTER) $^ $@' \
+	  --inputs $^ \
+	  --outputs $@ \
+	  --stdout-file $(LOGDIR)/restrict_function_pointer-log.txt \
+	  --pipeline-name "$(PROOF_UID)" \
+	  --ci-stage build \
+	  --description "$(PROOF_UID): restricting function pointers in project sources"
+
+# Fill static variable with unconstrained values
+$(HARNESS_GOTO)3.goto: $(HARNESS_GOTO)2.goto
+	$(LITANI) add-job \
+	  --command \
+	    '$(GOTO_INSTRUMENT) $(CBMC_VERBOSITY) $(NONDET_STATIC) $^ $@' \
+	  --inputs $^ \
+	  --outputs $@ \
+	  --stdout-file $(LOGDIR)/nondet_static-log.txt \
+	  --pipeline-name "$(PROOF_UID)" \
+	  --ci-stage build \
+	  --description "$(PROOF_UID): setting static variables to nondet"
+
+# Omit unused functions (sharpens coverage calculations)
+$(HARNESS_GOTO)4.goto: $(HARNESS_GOTO)3.goto
+	$(LITANI) add-job \
+	  --command \
+	    '$(GOTO_INSTRUMENT) $(CBMC_VERBOSITY) --drop-unused-functions $^ $@' \
+	  --inputs $^ \
+	  --outputs $@ \
+	  --stdout-file $(LOGDIR)/drop_unused_functions-log.txt \
+	  --pipeline-name "$(PROOF_UID)" \
+	  --ci-stage build \
+	  --description "$(PROOF_UID): dropping unused functions"
+
+# Omit initialization of unused global variables (reduces problem size)
+$(HARNESS_GOTO)5.goto: $(HARNESS_GOTO)4.goto
+	$(LITANI) add-job \
+	  --command \
+	    '$(GOTO_INSTRUMENT) $(CBMC_VERBOSITY) --slice-global-inits $^ $@' \
+	  --inputs $^ \
+	  --outputs $@ \
+	  --stdout-file $(LOGDIR)/slice_global_inits-log.txt \
+	  --pipeline-name "$(PROOF_UID)" \
+	  --ci-stage build \
+	  --description "$(PROOF_UID): slicing global initializations"
+
+# Replace function calls with function contracts
+# This must be done before enforcing function contracts,
+# since contract enforcement inlines all function calls.
+$(HARNESS_GOTO)6.goto: $(HARNESS_GOTO)5.goto
+	$(LITANI) add-job \
+	  --command \
+	    '$(GOTO_INSTRUMENT) $(CBMC_VERBOSITY) $(CBMC_USE_FUNCTION_CONTRACTS) $^ $@' \
+	  --inputs $^ \
+	  --outputs $@ \
+	  --stdout-file $(LOGDIR)/use_function_contracts-log.txt \
+	  --pipeline-name "$(PROOF_UID)" \
+	  --ci-stage build \
+	  --description "$(PROOF_UID): replacing function calls with function contracts"
+
+# Unwind loops for loop and function contracts
+$(HARNESS_GOTO)7.goto: $(HARNESS_GOTO)6.goto
+	$(LITANI) add-job \
+	  --command \
+	    '$(GOTO_INSTRUMENT) $(CBMC_VERBOSITY) $(CBMC_EARLY_UNWINDSET) $(CBMC_FLAG_UNWINDING_ASSERTIONS) $^ $@' \
+	  --inputs $^ \
+	  --outputs $@ \
+	  --stdout-file $(LOGDIR)/unwind_loops-log.txt \
+	  --pipeline-name "$(PROOF_UID)" \
+	  --ci-stage build \
+	  --description "$(PROOF_UID): unwinding loops"
+
+# Apply loop contracts
+$(HARNESS_GOTO)8.goto: $(HARNESS_GOTO)7.goto
+	$(LITANI) add-job \
+	  --command \
+	    '$(GOTO_INSTRUMENT) $(CBMC_VERBOSITY) $(CBMC_APPLY_LOOP_CONTRACTS) $^ $@' \
+	  --inputs $^ \
+	  --outputs $@ \
+	  --stdout-file $(LOGDIR)/apply_loop_contracts-log.txt \
+	  --pipeline-name "$(PROOF_UID)" \
+	  --ci-stage build \
+	  --description "$(PROOF_UID): applying loop contracts"
+
+# Check function contracts
+$(HARNESS_GOTO)9.goto: $(HARNESS_GOTO)8.goto
+	$(LITANI) add-job \
+	  --command \
+	    '$(GOTO_INSTRUMENT) $(CBMC_VERBOSITY) $(CBMC_CHECK_FUNCTION_CONTRACTS) $^ $@' \
+	  --inputs $^ \
+	  --outputs $@ \
+	  --stdout-file $(LOGDIR)/check_function_contracts-log.txt \
+	  --pipeline-name "$(PROOF_UID)" \
+	  --ci-stage build \
+	  --description "$(PROOF_UID): checking function contracts"
+
+# Final name for proof harness
+$(HARNESS_GOTO).goto: $(HARNESS_GOTO)9.goto
+	$(LITANI) add-job \
+	  --command 'cp $< $@' \
+	  --inputs $^ \
+	  --outputs $@ \
+	  --pipeline-name "$(PROOF_UID)" \
+	  --ci-stage build \
+	  --description "$(PROOF_UID): copying final goto-binary"
+
+################################################################
+# Targets to run the analysis commands
+
+$(LOGDIR)/result.txt: $(HARNESS_GOTO).goto
+	$(LITANI) add-job \
+	  $(POOL) \
+	  --command \
+	    '$(CBMC) $(CBMC_VERBOSITY) $(CBMCFLAGS) $(CBMC_FLAG_UNWINDING_ASSERTIONS) $(CHECKFLAGS) --trace $<' \
+	  --inputs $^ \
+	  --outputs $@ \
+	  --ci-stage test \
+	  --stdout-file $@ \
+	  $(MEMORY_PROFILING) \
+	  --ignore-returns 10 \
+	  --timeout $(CBMC_TIMEOUT) \
+	  --pipeline-name "$(PROOF_UID)" \
+	  --tags "stats-group:safety checks" \
+	  --stderr-file $(LOGDIR)/result-err-log.txt \
+	  --description "$(PROOF_UID): checking safety properties"
+
+$(LOGDIR)/result.xml: $(HARNESS_GOTO).goto
+	$(LITANI) add-job \
+	  $(POOL) \
+	  --command \
+	    '$(CBMC) $(CBMC_VERBOSITY) $(CBMCFLAGS) $(CBMC_FLAG_UNWINDING_ASSERTIONS) $(CHECKFLAGS) --trace --xml-ui $<' \
+	  --inputs $^ \
+	  --outputs $@ \
+	  --ci-stage test \
+	  --stdout-file $@ \
+	  $(MEMORY_PROFILING) \
+	  --ignore-returns 10 \
+	  --timeout $(CBMC_TIMEOUT) \
+	  --pipeline-name "$(PROOF_UID)" \
+	  --tags "stats-group:safety checks" \
+	  --stderr-file $(LOGDIR)/result-err-log.txt \
+	  --description "$(PROOF_UID): checking safety properties"
+
+$(LOGDIR)/property.xml: $(HARNESS_GOTO).goto
+	$(LITANI) add-job \
+	  --command \
+	    '$(CBMC) $(CBMC_VERBOSITY) $(CBMCFLAGS) $(CBMC_FLAG_UNWINDING_ASSERTIONS) $(CHECKFLAGS) --show-properties --xml-ui $<' \
+	  --inputs $^ \
+	  --outputs $@ \
+	  --ci-stage test \
+	  --stdout-file $@ \
+	  --ignore-returns 10 \
+	  --pipeline-name "$(PROOF_UID)" \
+	  --stderr-file $(LOGDIR)/property-err-log.txt \
+	  --description "$(PROOF_UID): printing safety properties"
+
+$(LOGDIR)/coverage.xml: $(HARNESS_GOTO).goto
+	$(LITANI) add-job \
+	  $(POOL) \
+	  --command \
+	    '$(CBMC) $(CBMC_VERBOSITY) $(CBMCFLAGS) $(COVERFLAGS) --cover location --xml-ui $<' \
+	  --inputs $^ \
+	  --outputs $@ \
+	  --ci-stage test \
+	  --stdout-file $@ \
+	  $(MEMORY_PROFILING) \
+	  --ignore-returns 10 \
+	  --timeout $(CBMC_TIMEOUT) \
+	  --pipeline-name "$(PROOF_UID)" \
+	  --tags "stats-group:coverage computation" \
+	  --stderr-file $(LOGDIR)/coverage-err-log.txt \
+	  --description "$(PROOF_UID): calculating coverage"
+
+define VIEWER_CMD
+  $(VIEWER) \
+    --result $(LOGDIR)/result.txt \
+    --block $(LOGDIR)/coverage.xml \
+    --property $(LOGDIR)/property.xml \
+    --srcdir $(SRCDIR) \
+    --goto $(HARNESS_GOTO).goto \
+    --htmldir $(PROOFDIR)/html
+endef
+export VIEWER_CMD
+
+$(PROOFDIR)/html: $(LOGDIR)/result.txt $(LOGDIR)/property.xml $(LOGDIR)/coverage.xml
+	$(LITANI) add-job \
+	  --command "$$VIEWER_CMD" \
+	  --inputs $^ \
+	  --outputs $(PROOFDIR)/html \
+	  --pipeline-name "$(PROOF_UID)" \
+	  --ci-stage report \
+	  --stdout-file $(LOGDIR)/viewer-log.txt \
+	  --description "$(PROOF_UID): generating report"
+
+
+# Caution: run make-source before running property and coverage checking
+# The current make-source script removes the goto binary
+$(LOGDIR)/source.json:
+	mkdir -p $(dir $@)
+	$(RM) -r $(GOTODIR)
+	$(MAKE_SOURCE) --srcdir $(SRCDIR) --wkdir $(PROOFDIR) > $@
+	$(RM) -r $(GOTODIR)
+
+define VIEWER2_CMD
+  $(VIEWER2) \
+    --result $(LOGDIR)/result.xml \
+    --coverage $(LOGDIR)/coverage.xml \
+    --property $(LOGDIR)/property.xml \
+    --srcdir $(SRCDIR) \
+    --goto $(HARNESS_GOTO).goto \
+    --reportdir $(PROOFDIR)/report \
+    --config $(PROOFDIR)/cbmc-viewer.json
+endef
+export VIEWER2_CMD
+
+# Omit logs/source.json from report generation until make-sources
+# works correctly with Makefiles that invoke the compiler with
+# mutliple source files at once.
+$(PROOFDIR)/report: $(LOGDIR)/result.xml $(LOGDIR)/property.xml $(LOGDIR)/coverage.xml
+	$(LITANI) add-job \
+	  --command "$$VIEWER2_CMD" \
+	  --inputs $^ \
+	  --outputs $(PROOFDIR)/report \
+	  --pipeline-name "$(PROOF_UID)" \
+	  --stdout-file $(LOGDIR)/viewer-log.txt \
+	  --ci-stage report \
+	  --description "$(PROOF_UID): generating report"
+
+litani-path:
+	@echo $(LITANI)
+
+# ##############################################################
+# Phony Rules
+#
+#	These rules provide a convenient way to run a single proof up to a
+#	certain stage. Users can browse into a proof directory and run
+#	"make -Bj 3 report" to generate a report for just that proof, or
+#	"make goto" to build the goto binary. Under the hood, this runs litani
+#	for just that proof.
+
+_goto: $(HARNESS_GOTO).goto
+goto:
+	@ echo Running 'litani init'
+	$(LITANI) init --project $(PROJECT_NAME)
+	@ echo Running 'litani add-job'
+	$(MAKE) -B _goto
+	@ echo Running 'litani build'
+	$(LITANI) run-build
+
+_result: $(LOGDIR)/result.txt
+result:
+	@ echo Running 'litani init'
+	$(LITANI) init --project $(PROJECT_NAME)
+	@ echo Running 'litani add-job'
+	$(MAKE) -B _result
+	@ echo Running 'litani build'
+	$(LITANI) run-build
+
+_property: $(LOGDIR)/property.xml
+property:
+	@ echo Running 'litani init'
+	$(LITANI) init --project $(PROJECT_NAME)
+	@ echo Running 'litani add-job'
+	$(MAKE) -B _property
+	@ echo Running 'litani build'
+	$(LITANI) run-build
+
+_coverage: $(LOGDIR)/coverage.xml
+coverage:
+	@ echo Running 'litani init'
+	$(LITANI) init --project $(PROJECT_NAME)
+	@ echo Running 'litani add-job'
+	$(MAKE) -B _coverage
+	@ echo Running 'litani build'
+	$(LITANI) run-build
+
+# Choose the invocation of cbmc-viewer depending on which version of
+# cbmc-viewer is installed.  The --version flag is not implemented in
+# version 1 --- it is an "unrecognized argument" --- but it is
+# implemented in version 2.
+_report1: $(PROOFDIR)/html
+_report2: $(PROOFDIR)/report
+_report:
+	(cbmc-viewer --version 2>&1 | grep "unrecognized argument" > /dev/null) && \
+		$(MAKE) -B _report1 || $(MAKE) -B _report2
+
+report report1 report2:
+	@ echo Running 'litani init'
+	$(LITANI) init --project $(PROJECT_NAME)
+	@ echo Running 'litani add-job'
+	$(MAKE) -B _report
+	@ echo Running 'litani build'
+	$(LITANI) run-build
+
+################################################################
+# Targets to clean up after ourselves
+clean:
+	-$(RM) $(DEPENDENT_GOTOS)
+	-$(RM) TAGS*
+	-$(RM) *~ \#*
+
+veryclean: clean
+	-$(RM) -r html report
+	-$(RM) -r $(LOGDIR) $(GOTODIR)
+
+.PHONY: \
+  _coverage \
+  _goto \
+  _property \
+  _report \
+  _report2 \
+  _result \
+  clean \
+  coverage \
+  goto \
+  litani-path \
+  property \
+  report \
+  report2 \
+  result \
+  setup_dependencies \
+  testdeps \
+  veryclean \
+  #
+
+################################################################
+
+# Rule for generating cbmc-batch.yaml, used by the CI at
+# https://github.com/awslabs/aws-batch-cbmc/
+
+JOB_OS ?= ubuntu16
+JOB_MEMORY ?= 32000
+
+# Proofs that are expected to fail should set EXPECTED to
+# "FAILED" in their Makefile. Values other than SUCCESSFUL
+# or FAILED will cause a CI error.
+EXPECTED ?= SUCCESSFUL
+
+define yaml_encode_options
+	"$(shell echo $(1) | sed 's/ ,/ /g' | sed 's/ /;/g')"
+endef
+
+CI_FLAGS = $(CBMCFLAGS) $(CHECKFLAGS) $(COVERFLAGS)
+
+cbmc-batch.yaml:
+	@$(RM) $@
+	@echo 'build_memory: $(JOB_MEMORY)' > $@
+	@echo 'cbmcflags: $(strip $(call yaml_encode_options,$(CI_FLAGS)))' >> $@
+	@echo 'coverage_memory: $(JOB_MEMORY)' >> $@
+	@echo 'expected: $(EXPECTED)' >> $@
+	@echo 'goto: $(HARNESS_GOTO).goto' >> $@
+	@echo 'jobos: $(JOB_OS)' >> $@
+	@echo 'property_memory: $(JOB_MEMORY)' >> $@
+	@echo 'report_memory: $(JOB_MEMORY)' >> $@
+
+.PHONY: cbmc-batch.yaml
+
+################################################################
+
+# Run "make echo-proof-uid" to print the proof ID of a proof. This can be
+# used by scripts to ensure that every proof has an ID, that there are
+# no duplicates, etc.
+
+.PHONY: echo-proof-uid
+echo-proof-uid:
+	@echo $(PROOF_UID)
+
+.PHONY: echo-project-name
+echo-project-name:
+	@echo $(PROJECT_NAME)
+
+################################################################
+
+# Project-specific targets requiring values defined above
+sinclude $(PROOF_ROOT)/Makefile-project-targets
+
+# CI-specific targets to drive cbmc in CI
+sinclude $(PROOF_ROOT)/Makefile-project-testing
+
+################################################################

--- a/tests/cbmc/proofs/README.md
+++ b/tests/cbmc/proofs/README.md
@@ -1,1 +1,27 @@
-../templates/template-for-repository/proofs/README.md
+CBMC proofs
+===========
+
+This directory contains the CBMC proofs.  Each proof is in its own
+directory.
+
+This directory includes four Makefiles.
+
+One Makefile describes the basic workflow for building and running proofs:
+
+* Makefile.common:
+    * make: builds the goto binary, does the cbmc property checking
+	  and coverage checking, and builds the final report.
+	* make goto: builds the goto binary
+	* make result: does cbmc property checking
+	* make coverage: does cbmc coverage checking
+	* make report: builds the final report
+
+Three included Makefiles describe project-specific settings and can override
+definitions in Makefile.common:
+
+* Makefile-project-defines: definitions like compiler flags
+  required to build the goto binaries, and definitions to override
+  definitions in Makefile.common.
+* Makefile-project-targets: other make targets needed for the project
+* Makefile-project-testing: other definitions and targets needed for
+  unit testing or continuous integration.

--- a/tests/cbmc/proofs/lib/summarize.py
+++ b/tests/cbmc/proofs/lib/summarize.py
@@ -1,0 +1,92 @@
+# Copyright Amazon.com, Inc. or its affiliates. All Rights Reserved.
+# SPDX-License-Identifier: MIT-0
+
+import json
+import logging
+
+
+def _get_max_length_per_column_list(data):
+    ret = [len(item) + 1 for item in data[0]]
+    for row in data[1:]:
+        for idx, item in enumerate(row):
+            ret[idx] = max(ret[idx], len(item) + 1)
+    return ret
+
+
+def _get_table_header_separator(max_length_per_column_list):
+    line_sep = ""
+    for max_length_of_word_in_col in max_length_per_column_list:
+        line_sep += "|" + "-" * (max_length_of_word_in_col + 1)
+    line_sep += "|\n"
+    return line_sep
+
+
+def _get_entries(max_length_per_column_list, row_data):
+    entries = []
+    for row in row_data:
+        entry = ""
+        for idx, word in enumerate(row):
+            max_length_of_word_in_col = max_length_per_column_list[idx]
+            space_formatted_word = (max_length_of_word_in_col - len(word)) * " "
+            entry += "| " + word + space_formatted_word
+        entry += "|\n"
+        entries.append(entry)
+    return entries
+
+
+def _get_rendered_table(data):
+    table = []
+    max_length_per_column_list = _get_max_length_per_column_list(data)
+    entries = _get_entries(max_length_per_column_list, data)
+    for idx, entry in enumerate(entries):
+        if idx == 1:
+            line_sep = _get_table_header_separator(max_length_per_column_list)
+            table.append(line_sep)
+        table.append(entry)
+    table.append("\n")
+    return "".join(table)
+
+
+def _get_status_and_proof_summaries(run_dict):
+    """Parse a dict representing a Litani run and create lists summarizing the
+    proof results.
+
+    Parameters
+    ----------
+    run_dict
+        A dictionary representing a Litani run.
+
+    Returns
+    -------
+    A list of 2 lists.
+    The first sub-list maps a status to the number of proofs with that status.
+    The second sub-list maps each proof to its status.
+    """
+    count_statuses = {}
+    proofs = [["Proof", "Status"]]
+    for proof_pipeline in run_dict["pipelines"]:
+        status_pretty_name = proof_pipeline["status"].title().replace("_", " ")
+        try:
+            count_statuses[status_pretty_name] += 1
+        except KeyError:
+            count_statuses[status_pretty_name] = 1
+        proof = proof_pipeline["name"]
+        proofs.append([proof, status_pretty_name])
+    statuses = [["Status", "Count"]]
+    for status, count in count_statuses.items():
+        statuses.append([status, str(count)])
+    return [statuses, proofs]
+
+
+def print_proof_results(out_file):
+    """
+    Print 2 strings that summarize the proof results.
+    When printing, each string will render as a GitHub flavored Markdown table.
+    """
+    try:
+        with open(out_file, encoding='utf-8') as run_json:
+            run_dict = json.load(run_json)
+            for summary in _get_status_and_proof_summaries(run_dict):
+                print(_get_rendered_table(summary))
+    except Exception as ex: # pylint: disable=broad-except
+        logging.critical("Could not print results. Exception: %s", str(ex))

--- a/tests/cbmc/proofs/run-cbmc-proofs.py
+++ b/tests/cbmc/proofs/run-cbmc-proofs.py
@@ -1,1 +1,413 @@
-../templates/template-for-repository/proofs/run-cbmc-proofs.py
+#!/usr/bin/env python3
+#
+# Copyright Amazon.com, Inc. or its affiliates. All Rights Reserved.
+# SPDX-License-Identifier: MIT-0
+
+
+import argparse
+import asyncio
+import json
+import logging
+import math
+import os
+import pathlib
+import re
+import subprocess
+import sys
+import tempfile
+
+from lib.summarize import print_proof_results
+
+
+DESCRIPTION = "Configure and run all CBMC proofs in parallel"
+
+# Keep the epilog hard-wrapped at 70 characters, as it gets printed
+# verbatim in the terminal. 70 characters stops here --------------> |
+EPILOG = """
+This tool automates the process of running `make report` in each of
+the CBMC proof directories. The tool calculates the dependency graph
+of all tasks needed to build, run, and report on all the proofs, and
+executes these tasks in parallel.
+
+The tool is roughly equivalent to doing this:
+
+        litani init --project "my-cool-project";
+
+        find . -name cbmc-proof.txt | while read -r proof; do
+            pushd $(dirname ${proof});
+
+            # The `make _report` rule adds a single proof to litani
+            # without running it
+            make _report;
+
+            popd;
+        done
+
+        litani run-build;
+
+except that it is much faster and provides some convenience options.
+The CBMC CI runs this script with no arguments to build and run all
+proofs in parallel. The value of "my-cool-project" is taken from the
+PROJECT_NAME variable in Makefile-project-defines.
+
+The --no-standalone argument omits the `litani init` and `litani
+run-build`; use it when you want to add additional proof jobs, not
+just the CBMC ones. In that case, you would run `litani init`
+yourself; then run `run-cbmc-proofs --no-standalone`; add any
+additional jobs that you want to execute with `litani add-job`; and
+finally run `litani run-build`.
+
+The litani dashboard will be written under the `output` directory; the
+cbmc-viewer reports remain in the `$PROOF_DIR/report` directory. The
+HTML dashboard from the latest Litani run will always be symlinked to
+`output/latest/html/index.html`, so you can keep that page open in
+your browser and reload the page whenever you re-run this script.
+"""
+# 70 characters stops here ----------------------------------------> |
+
+
+def get_project_name():
+    cmd = [
+        "make",
+        "--no-print-directory",
+        "-f", "Makefile.common",
+        "echo-project-name",
+    ]
+    logging.debug(" ".join(cmd))
+    proc = subprocess.run(cmd, universal_newlines=True, stdout=subprocess.PIPE, check=False)
+    if proc.returncode:
+        logging.critical("could not run make to determine project name")
+        sys.exit(1)
+    if not proc.stdout.strip():
+        logging.warning(
+            "project name has not been set; using generic name instead. "
+            "Set the PROJECT_NAME value in Makefile-project-defines to "
+            "remove this warning")
+        return "<PROJECT NAME HERE>"
+    return proc.stdout.strip()
+
+
+def get_args():
+    pars = argparse.ArgumentParser(
+        description=DESCRIPTION, epilog=EPILOG,
+        formatter_class=argparse.RawDescriptionHelpFormatter)
+    for arg in [{
+            "flags": ["-j", "--parallel-jobs"],
+            "type": int,
+            "metavar": "N",
+            "help": "run at most N proof jobs in parallel",
+    }, {
+            "flags": ["--fail-on-proof-failure"],
+            "action": "store_true",
+            "help": "exit with return code `10' if any proof failed"
+                    " (default: exit 0)",
+    }, {
+            "flags": ["--no-standalone"],
+            "action": "store_true",
+            "help": "only configure proofs: do not initialize nor run",
+    }, {
+            "flags": ["-p", "--proofs"],
+            "nargs": "+",
+            "metavar": "DIR",
+            "help": "only run proof in directory DIR (can pass more than one)",
+    }, {
+            "flags": ["--project-name"],
+            "metavar": "NAME",
+            "default": get_project_name(),
+            "help": "project name for report. Default: %(default)s",
+    }, {
+            "flags": ["--marker-file"],
+            "metavar": "FILE",
+            "default": "cbmc-proof.txt",
+            "help": (
+                "name of file that marks proof directories. Default: "
+                "%(default)s"),
+    }, {
+            "flags": ["--no-memory-profile"],
+            "action": "store_true",
+            "help": "disable memory profiling, even if Litani supports it"
+    }, {
+            "flags": ["--no-expensive-limit"],
+            "action": "store_true",
+            "help": "do not limit parallelism of 'EXPENSIVE' jobs",
+    }, {
+            "flags": ["--expensive-jobs-parallelism"],
+            "metavar": "N",
+            "default": 1,
+            "type": int,
+            "help": (
+                "how many proof jobs marked 'EXPENSIVE' to run in parallel. "
+                "Default: %(default)s"),
+    }, {
+            "flags": ["--verbose"],
+            "action": "store_true",
+            "help": "verbose output",
+    }, {
+            "flags": ["--debug"],
+            "action": "store_true",
+            "help": "debug output",
+    }, {
+            "flags": ["--summarize"],
+            "action": "store_true",
+            "help": "summarize proof results with two tables on stdout",
+    }, {
+            "flags": ["--version"],
+            "action": "version",
+            "version": "CBMC starter kit 2.4",
+            "help": "display version and exit"
+    }]:
+        flags = arg.pop("flags")
+        pars.add_argument(*flags, **arg)
+    return pars.parse_args()
+
+
+def set_up_logging(verbose):
+    if verbose:
+        level = logging.DEBUG
+    else:
+        level = logging.WARNING
+    logging.basicConfig(
+        format="run-cbmc-proofs: %(message)s", level=level)
+
+
+def task_pool_size():
+    ret = os.cpu_count()
+    if ret is None or ret < 3:
+        return 1
+    return ret - 2
+
+
+def print_counter(counter):
+    # pylint: disable=consider-using-f-string
+    print("\rConfiguring CBMC proofs: "
+          "{complete:{width}} / {total:{width}}".format(**counter), end="", file=sys.stderr)
+
+
+def get_proof_dirs(proof_root, proof_list, marker_file):
+    if proof_list is not None:
+        proofs_remaining = list(proof_list)
+    else:
+        proofs_remaining = []
+
+    for root, _, fyles in os.walk(proof_root):
+        proof_name = str(pathlib.Path(root).name)
+        if root != str(proof_root) and ".litani_cache_dir" in fyles:
+            pathlib.Path(f"{root}/.litani_cache_dir").unlink()
+        if proof_list and proof_name not in proof_list:
+            continue
+        if proof_list and proof_name in proofs_remaining:
+            proofs_remaining.remove(proof_name)
+        if marker_file in fyles:
+            yield root
+
+    if proofs_remaining:
+        logging.critical(
+            "The following proofs were not found: %s",
+            ", ".join(proofs_remaining))
+        sys.exit(1)
+
+
+def run_build(litani, jobs, fail_on_proof_failure, summarize):
+    cmd = [str(litani), "run-build"]
+    if jobs:
+        cmd.extend(["-j", str(jobs)])
+    if fail_on_proof_failure:
+        cmd.append("--fail-on-pipeline-failure")
+    if summarize:
+        out_file = pathlib.Path(tempfile.gettempdir(), "run.json").resolve()
+        cmd.extend(["--out-file", str(out_file)])
+
+    logging.debug(" ".join(cmd))
+    proc = subprocess.run(cmd, check=False)
+    if proc.returncode:
+        if fail_on_proof_failure:
+            logging.error("One or more proofs failed")
+            sys.exit(10)
+        logging.critical("Failed to run litani run-build")
+        sys.exit(1)
+
+    if summarize:
+        print_proof_results(out_file)
+        out_file.unlink()
+
+
+def get_litani_path(proof_root):
+    cmd = [
+        "make",
+        "--no-print-directory",
+        f"PROOF_ROOT={proof_root}",
+        "-f", "Makefile.common",
+        "litani-path",
+    ]
+    logging.debug(" ".join(cmd))
+    proc = subprocess.run(cmd, universal_newlines=True, stdout=subprocess.PIPE, check=False)
+    if proc.returncode:
+        logging.critical("Could not determine path to litani")
+        sys.exit(1)
+    return proc.stdout.strip()
+
+
+def get_litani_capabilities(litani_path):
+    cmd = [litani_path, "print-capabilities"]
+    proc = subprocess.run(
+        cmd, text=True, stdout=subprocess.PIPE, stderr=subprocess.DEVNULL, check=False)
+    if proc.returncode:
+        return []
+    try:
+        return json.loads(proc.stdout)
+    except RuntimeError:
+        logging.warning("Could not load litani capabilities: '%s'", proc.stdout)
+        return []
+
+
+def check_uid_uniqueness(proof_dir, proof_uids):
+    with (pathlib.Path(proof_dir) / "Makefile").open() as handle:
+        for line in handle:
+            match = re.match(r"^PROOF_UID\s*=\s*(?P<uid>\w+)", line)
+            if not match:
+                continue
+            if match["uid"] not in proof_uids:
+                proof_uids[match["uid"]] = proof_dir
+                return
+
+            logging.critical(
+                "The Makefile in directory '%s' should have a different "
+                "PROOF_UID than the Makefile in directory '%s'",
+                proof_dir, proof_uids[match["uid"]])
+            sys.exit(1)
+
+    logging.critical(
+        "The Makefile in directory '%s' should contain a line like", proof_dir)
+    logging.critical("PROOF_UID = ...")
+    logging.critical("with a unique identifier for the proof.")
+    sys.exit(1)
+
+
+def should_enable_memory_profiling(litani_caps, args):
+    if args.no_memory_profile:
+        return False
+    return "memory_profile" in litani_caps
+
+
+def should_enable_pools(litani_caps, args):
+    if args.no_expensive_limit:
+        return False
+    return "pools" in litani_caps
+
+
+async def configure_proof_dirs( # pylint: disable=too-many-arguments
+    queue, counter, proof_uids, enable_pools, enable_memory_profiling, debug):
+    while True:
+        print_counter(counter)
+        path = str(await queue.get())
+
+        check_uid_uniqueness(path, proof_uids)
+
+        pools = ["ENABLE_POOLS=true"] if enable_pools else []
+        profiling = [
+            "ENABLE_MEMORY_PROFILING=true"] if enable_memory_profiling else []
+
+        # Allow interactive tasks to preempt proof configuration
+        proc = await asyncio.create_subprocess_exec(
+            "nice", "-n", "15", "make", *pools,
+            *profiling, "-B", "_report", "" if debug else "--quiet", cwd=path,
+            stdout=asyncio.subprocess.PIPE, stderr=asyncio.subprocess.PIPE)
+        stdout, stderr = await proc.communicate()
+        logging.debug("returncode: %s", str(proc.returncode))
+        logging.debug("stdout:")
+        for line in stdout.decode().splitlines():
+            logging.debug(line)
+        logging.debug("stderr:")
+        for line in stderr.decode().splitlines():
+            logging.debug(line)
+
+        counter["fail" if proc.returncode else "pass"].append(path)
+        counter["complete"] += 1
+
+        print_counter(counter)
+        queue.task_done()
+
+
+async def main(): # pylint: disable=too-many-locals
+    args = get_args()
+    set_up_logging(args.verbose)
+
+    proof_root = pathlib.Path(os.getcwd())
+    litani = get_litani_path(proof_root)
+
+    litani_caps = get_litani_capabilities(litani)
+    enable_pools = should_enable_pools(litani_caps, args)
+    init_pools = [
+        "--pools", f"expensive:{args.expensive_jobs_parallelism}"
+    ] if enable_pools else []
+
+    if not args.no_standalone:
+        cmd = [
+            str(litani), "init", *init_pools, "--project", args.project_name,
+            "--no-print-out-dir",
+        ]
+
+        if "output_directory_flags" in litani_caps:
+            out_prefix = proof_root / "output"
+            out_symlink = out_prefix / "latest"
+            out_index = out_symlink / "html" / "index.html"
+            cmd.extend([
+                "--output-prefix", str(out_prefix),
+                "--output-symlink", str(out_symlink),
+            ])
+            print(
+                "\nFor your convenience, the output of this run will be symbolically linked to ",
+                out_index, "\n")
+
+        logging.debug(" ".join(cmd))
+        proc = subprocess.run(cmd, check=False)
+        if proc.returncode:
+            logging.critical("Failed to run litani init")
+            sys.exit(1)
+
+    proof_dirs = list(get_proof_dirs(
+        proof_root, args.proofs, args.marker_file))
+    if not proof_dirs:
+        logging.critical("No proof directories found")
+        sys.exit(1)
+
+    proof_queue = asyncio.Queue()
+    for proof_dir in proof_dirs:
+        proof_queue.put_nowait(proof_dir)
+
+    counter = {
+        "pass": [],
+        "fail": [],
+        "complete": 0,
+        "total": len(proof_dirs),
+        "width": int(math.log10(len(proof_dirs))) + 1
+    }
+
+    proof_uids = {}
+    tasks = []
+
+    enable_memory_profiling = should_enable_memory_profiling(litani_caps, args)
+
+    for _ in range(task_pool_size()):
+        task = asyncio.create_task(configure_proof_dirs(
+            proof_queue, counter, proof_uids, enable_pools,
+            enable_memory_profiling, args.debug))
+        tasks.append(task)
+
+    await proof_queue.join()
+
+    print_counter(counter)
+    print("", file=sys.stderr)
+
+    if counter["fail"]:
+        logging.critical(
+            "Failed to configure the following proofs:\n%s", "\n".join(
+                [str(f) for f in counter["fail"]]))
+        sys.exit(1)
+
+    if not args.no_standalone:
+        run_build(litani, args.parallel_jobs, args.fail_on_proof_failure, args.summarize)
+
+
+if __name__ == "__main__":
+    asyncio.run(main())

--- a/tests/cbmc/proofs/s2n_add_overflow/Makefile
+++ b/tests/cbmc/proofs/s2n_add_overflow/Makefile
@@ -1,4 +1,3 @@
-# Copyright Amazon.com, Inc. or its affiliates. All Rights Reserved.
 #
 # Licensed under the Apache License, Version 2.0 (the "License"). You may not use
 # this file except in compliance with the License. A copy of the License is

--- a/tests/cbmc/proofs/s2n_add_overflow/Makefile.backup
+++ b/tests/cbmc/proofs/s2n_add_overflow/Makefile.backup
@@ -1,0 +1,29 @@
+# Copyright Amazon.com, Inc. or its affiliates. All Rights Reserved.
+#
+# Licensed under the Apache License, Version 2.0 (the "License"). You may not use
+# this file except in compliance with the License. A copy of the License is
+# located at
+#
+#     http://aws.amazon.com/apache2.0/
+#
+# or in the "license" file accompanying this file. This file is distributed on an
+# "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or
+# implied. See the License for the specific language governing permissions and
+# limitations under the License.
+
+CBMCFLAGS +=
+
+PROOF_UID = s2n_add_overflow
+HARNESS_ENTRY = $(PROOF_UID)_harness
+HARNESS_FILE = $(HARNESS_ENTRY).c
+
+PROOF_SOURCES += $(PROOFDIR)/$(HARNESS_FILE)
+PROOF_SOURCES += $(PROOF_SOURCE)/make_common_datastructures.c
+
+PROOF_SOURCES += $(PROOF_STUB)/s2n_calculate_stacktrace.c
+
+PROJECT_SOURCES += $(SRCDIR)/utils/s2n_safety.c
+
+UNWINDSET +=
+
+include ../Makefile.common

--- a/tests/cbmc/proofs/s2n_align_to/Makefile
+++ b/tests/cbmc/proofs/s2n_align_to/Makefile
@@ -1,4 +1,3 @@
-# Copyright Amazon.com, Inc. or its affiliates. All Rights Reserved.
 #
 # Licensed under the Apache License, Version 2.0 (the "License"). You may not use
 # this file except in compliance with the License. A copy of the License is

--- a/tests/cbmc/proofs/s2n_align_to/Makefile.backup
+++ b/tests/cbmc/proofs/s2n_align_to/Makefile.backup
@@ -1,0 +1,30 @@
+# Copyright Amazon.com, Inc. or its affiliates. All Rights Reserved.
+#
+# Licensed under the Apache License, Version 2.0 (the "License"). You may not use
+# this file except in compliance with the License. A copy of the License is
+# located at
+#
+#     http://aws.amazon.com/apache2.0/
+#
+# or in the "license" file accompanying this file. This file is distributed on an
+# "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or
+# implied. See the License for the specific language governing permissions and
+# limitations under the License.
+
+# Expected runtime is 5 seconds.
+
+CBMCFLAGS +=
+
+PROOF_UID = s2n_align_to
+HARNESS_ENTRY = $(PROOF_UID)_harness
+HARNESS_FILE = $(HARNESS_ENTRY).c
+
+PROOF_SOURCES += $(PROOFDIR)/$(HARNESS_FILE)
+PROOF_SOURCES += $(PROOF_SOURCE)/make_common_datastructures.c
+PROOF_SOURCES += $(PROOF_STUB)/s2n_calculate_stacktrace.c
+
+PROJECT_SOURCES += $(SRCDIR)/utils/s2n_safety.c
+
+UNWINDSET +=
+
+include ../Makefile.common

--- a/tests/cbmc/proofs/s2n_alloc/Makefile
+++ b/tests/cbmc/proofs/s2n_alloc/Makefile
@@ -1,4 +1,3 @@
-# Copyright Amazon.com, Inc. or its affiliates. All Rights Reserved.
 #
 # Licensed under the Apache License, Version 2.0 (the "License"). You may not use
 # this file except in compliance with the License. A copy of the License is

--- a/tests/cbmc/proofs/s2n_alloc/Makefile.backup
+++ b/tests/cbmc/proofs/s2n_alloc/Makefile.backup
@@ -1,0 +1,47 @@
+# Copyright Amazon.com, Inc. or its affiliates. All Rights Reserved.
+#
+# Licensed under the Apache License, Version 2.0 (the "License"). You may not use
+# this file except in compliance with the License. A copy of the License is
+# located at
+#
+#     http://aws.amazon.com/apache2.0/
+#
+# or in the "license" file accompanying this file. This file is distributed on an
+# "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or
+# implied. See the License for the specific language governing permissions and
+# limitations under the License.
+
+# Expected runtime is 20 seconds.
+
+CHECKFLAGS +=
+
+DEFINES += -DMADV_DONTDUMP=1
+
+PROOF_UID = s2n_alloc
+HARNESS_ENTRY = $(PROOF_UID)_harness
+HARNESS_FILE = $(HARNESS_ENTRY).c
+
+PROOF_SOURCES += $(PROOFDIR)/$(HARNESS_FILE)
+PROOF_SOURCES += $(PROOF_SOURCE)/cbmc_utils.c
+PROOF_SOURCES += $(PROOF_SOURCE)/make_common_datastructures.c
+PROOF_SOURCES += $(PROOF_STUB)/madvise.c
+PROOF_SOURCES += $(PROOF_STUB)/mlock.c
+PROOF_SOURCES += $(PROOF_STUB)/munlock.c
+PROOF_SOURCES += $(PROOF_STUB)/posix_memalign_override.c
+PROOF_SOURCES += $(PROOF_STUB)/s2n_calculate_stacktrace.c
+PROOF_SOURCES += $(PROOF_STUB)/sysconf.c
+
+PROJECT_SOURCES += $(SRCDIR)/utils/s2n_blob.c
+PROJECT_SOURCES += $(SRCDIR)/utils/s2n_ensure.c
+PROJECT_SOURCES += $(SRCDIR)/utils/s2n_mem.c
+PROJECT_SOURCES += $(SRCDIR)/utils/s2n_safety.c
+PROJECT_SOURCES += $(SRCDIR)/utils/s2n_result.c
+
+# We abstract these functions because manual inspection demonstrates they are unreachable.
+REMOVE_FUNCTION_BODY += __CPROVER_file_local_s2n_mem_c_s2n_mem_cleanup_impl
+REMOVE_FUNCTION_BODY += s2n_blob_slice
+REMOVE_FUNCTION_BODY += s2n_ensure_memcpy_trace
+
+UNWINDSET +=
+
+include ../Makefile.common

--- a/tests/cbmc/proofs/s2n_array_capacity/Makefile
+++ b/tests/cbmc/proofs/s2n_array_capacity/Makefile
@@ -1,4 +1,3 @@
-# Copyright Amazon.com, Inc. or its affiliates. All Rights Reserved.
 #
 # Licensed under the Apache License, Version 2.0 (the "License"). You may not use
 # this file except in compliance with the License. A copy of the License is

--- a/tests/cbmc/proofs/s2n_array_capacity/Makefile.backup
+++ b/tests/cbmc/proofs/s2n_array_capacity/Makefile.backup
@@ -1,0 +1,39 @@
+# Copyright Amazon.com, Inc. or its affiliates. All Rights Reserved.
+#
+# Licensed under the Apache License, Version 2.0 (the "License"). You may not use
+# this file except in compliance with the License. A copy of the License is
+# located at
+#
+#     http://aws.amazon.com/apache2.0/
+#
+# or in the "license" file accompanying this file. This file is distributed on an
+# "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or
+# implied. See the License for the specific language governing permissions and
+# limitations under the License.
+
+# Expected runtime is less than 15 seconds.
+
+MAX_ARRAY_LEN = 10
+DEFINES += -DMAX_ARRAY_LEN=$(MAX_ARRAY_LEN)
+
+MAX_ARRAY_ELEMENT_SIZE = 10
+DEFINES += -DMAX_ARRAY_ELEMENT_SIZE=$(MAX_ARRAY_ELEMENT_SIZE)
+
+CBMCFLAGS +=
+
+PROOF_UID = s2n_array_capacity
+HARNESS_ENTRY = $(PROOF_UID)_harness
+HARNESS_FILE = $(HARNESS_ENTRY).c
+
+PROOF_SOURCES += $(PROOFDIR)/$(HARNESS_FILE)
+PROOF_SOURCES += $(PROOF_SOURCE)/make_common_datastructures.c
+PROOF_SOURCES += $(PROOF_STUB)/s2n_calculate_stacktrace.c
+
+PROJECT_SOURCES += $(SRCDIR)/utils/s2n_array.c
+PROJECT_SOURCES += $(SRCDIR)/utils/s2n_blob.c
+PROJECT_SOURCES += $(SRCDIR)/utils/s2n_result.c
+PROJECT_SOURCES += $(SRCDIR)/utils/s2n_safety.c
+
+UNWINDSET +=
+
+include ../Makefile.common

--- a/tests/cbmc/proofs/s2n_array_free/Makefile
+++ b/tests/cbmc/proofs/s2n_array_free/Makefile
@@ -1,4 +1,3 @@
-# Copyright Amazon.com, Inc. or its affiliates. All Rights Reserved.
 #
 # Licensed under the Apache License, Version 2.0 (the "License"). You may not use
 # this file except in compliance with the License. A copy of the License is

--- a/tests/cbmc/proofs/s2n_array_free/Makefile.backup
+++ b/tests/cbmc/proofs/s2n_array_free/Makefile.backup
@@ -1,0 +1,40 @@
+# Copyright Amazon.com, Inc. or its affiliates. All Rights Reserved.
+#
+# Licensed under the Apache License, Version 2.0 (the "License"). You may not use
+# this file except in compliance with the License. A copy of the License is
+# located at
+#
+#     http://aws.amazon.com/apache2.0/
+#
+# or in the "license" file accompanying this file. This file is distributed on an
+# "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or
+# implied. See the License for the specific language governing permissions and
+# limitations under the License.
+
+# Expected runtime is less than 10 seconds.
+
+CBMCFLAGS += --memory-leak-check
+
+PROOF_UID = s2n_array_free
+HARNESS_ENTRY = $(PROOF_UID)_harness
+HARNESS_FILE = $(HARNESS_ENTRY).c
+
+PROOF_SOURCES += $(PROOFDIR)/$(HARNESS_FILE)
+PROOF_SOURCES += $(PROOF_SOURCE)/cbmc_utils.c
+PROOF_SOURCES += $(PROOF_SOURCE)/make_common_datastructures.c
+PROOF_SOURCES += $(PROOF_STUB)/munlock.c
+PROOF_SOURCES += $(PROOF_STUB)/s2n_calculate_stacktrace.c
+PROOF_SOURCES += $(PROOF_STUB)/sysconf.c
+
+PROJECT_SOURCES += $(SRCDIR)/utils/s2n_array.c
+PROJECT_SOURCES += $(SRCDIR)/utils/s2n_blob.c
+PROJECT_SOURCES += $(SRCDIR)/utils/s2n_mem.c
+PROJECT_SOURCES += $(SRCDIR)/utils/s2n_result.c
+PROJECT_SOURCES += $(SRCDIR)/utils/s2n_safety.c
+
+# We abstract this function because manual inspection demonstrates it is unreachable.
+REMOVE_FUNCTION_BODY += __CPROVER_file_local_s2n_mem_c_s2n_mem_cleanup_impl
+
+UNWINDSET +=
+
+include ../Makefile.common

--- a/tests/cbmc/proofs/s2n_array_free_p/Makefile
+++ b/tests/cbmc/proofs/s2n_array_free_p/Makefile
@@ -1,4 +1,3 @@
-# Copyright Amazon.com, Inc. or its affiliates. All Rights Reserved.
 #
 # Licensed under the Apache License, Version 2.0 (the "License"). You may not use
 # this file except in compliance with the License. A copy of the License is

--- a/tests/cbmc/proofs/s2n_array_free_p/Makefile.backup
+++ b/tests/cbmc/proofs/s2n_array_free_p/Makefile.backup
@@ -1,0 +1,40 @@
+# Copyright Amazon.com, Inc. or its affiliates. All Rights Reserved.
+#
+# Licensed under the Apache License, Version 2.0 (the "License"). You may not use
+# this file except in compliance with the License. A copy of the License is
+# located at
+#
+#     http://aws.amazon.com/apache2.0/
+#
+# or in the "license" file accompanying this file. This file is distributed on an
+# "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or
+# implied. See the License for the specific language governing permissions and
+# limitations under the License.
+
+# Expected runtime is less than 10 seconds.
+
+CBMCFLAGS += --memory-leak-check
+
+PROOF_UID = s2n_array_free_p
+HARNESS_ENTRY = $(PROOF_UID)_harness
+HARNESS_FILE = $(HARNESS_ENTRY).c
+
+PROOF_SOURCES += $(PROOFDIR)/$(HARNESS_FILE)
+PROOF_SOURCES += $(PROOF_SOURCE)/cbmc_utils.c
+PROOF_SOURCES += $(PROOF_SOURCE)/make_common_datastructures.c
+PROOF_SOURCES += $(PROOF_STUB)/munlock.c
+PROOF_SOURCES += $(PROOF_STUB)/s2n_calculate_stacktrace.c
+PROOF_SOURCES += $(PROOF_STUB)/sysconf.c
+
+PROJECT_SOURCES += $(SRCDIR)/utils/s2n_array.c
+PROJECT_SOURCES += $(SRCDIR)/utils/s2n_blob.c
+PROJECT_SOURCES += $(SRCDIR)/utils/s2n_mem.c
+PROJECT_SOURCES += $(SRCDIR)/utils/s2n_result.c
+PROJECT_SOURCES += $(SRCDIR)/utils/s2n_safety.c
+
+# We abstract this function because manual inspection demonstrates it is unreachable.
+REMOVE_FUNCTION_BODY += __CPROVER_file_local_s2n_mem_c_s2n_mem_cleanup_impl
+
+UNWINDSET +=
+
+include ../Makefile.common

--- a/tests/cbmc/proofs/s2n_array_get/Makefile
+++ b/tests/cbmc/proofs/s2n_array_get/Makefile
@@ -1,4 +1,3 @@
-# Copyright Amazon.com, Inc. or its affiliates. All Rights Reserved.
 #
 # Licensed under the Apache License, Version 2.0 (the "License"). You may not use
 # this file except in compliance with the License. A copy of the License is

--- a/tests/cbmc/proofs/s2n_array_get/Makefile.backup
+++ b/tests/cbmc/proofs/s2n_array_get/Makefile.backup
@@ -1,0 +1,39 @@
+# Copyright Amazon.com, Inc. or its affiliates. All Rights Reserved.
+#
+# Licensed under the Apache License, Version 2.0 (the "License"). You may not use
+# this file except in compliance with the License. A copy of the License is
+# located at
+#
+#     http://aws.amazon.com/apache2.0/
+#
+# or in the "license" file accompanying this file. This file is distributed on an
+# "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or
+# implied. See the License for the specific language governing permissions and
+# limitations under the License.
+
+# Expected runtime is less than 10 seconds.
+
+MAX_ARRAY_LEN = 100
+DEFINES += -DMAX_ARRAY_LEN=$(MAX_ARRAY_LEN)
+
+MAX_ARRAY_ELEMENT_SIZE = 100
+DEFINES += -DMAX_ARRAY_ELEMENT_SIZE=$(MAX_ARRAY_ELEMENT_SIZE)
+
+CBMCFLAGS +=
+
+PROOF_UID = s2n_array_get
+HARNESS_ENTRY = $(PROOF_UID)_harness
+HARNESS_FILE = $(HARNESS_ENTRY).c
+
+PROOF_SOURCES += $(PROOFDIR)/$(HARNESS_FILE)
+PROOF_SOURCES += $(PROOF_SOURCE)/make_common_datastructures.c
+PROOF_SOURCES += $(PROOF_STUB)/s2n_calculate_stacktrace.c
+
+PROJECT_SOURCES += $(SRCDIR)/utils/s2n_array.c
+PROJECT_SOURCES += $(SRCDIR)/utils/s2n_blob.c
+PROJECT_SOURCES += $(SRCDIR)/utils/s2n_result.c
+PROJECT_SOURCES += $(SRCDIR)/utils/s2n_safety.c
+
+UNWINDSET +=
+
+include ../Makefile.common

--- a/tests/cbmc/proofs/s2n_array_init/Makefile
+++ b/tests/cbmc/proofs/s2n_array_init/Makefile
@@ -1,4 +1,3 @@
-# Copyright Amazon.com, Inc. or its affiliates. All Rights Reserved.
 #
 # Licensed under the Apache License, Version 2.0 (the "License"). You may not use
 # this file except in compliance with the License. A copy of the License is

--- a/tests/cbmc/proofs/s2n_array_init/Makefile.backup
+++ b/tests/cbmc/proofs/s2n_array_init/Makefile.backup
@@ -1,0 +1,43 @@
+# Copyright Amazon.com, Inc. or its affiliates. All Rights Reserved.
+#
+# Licensed under the Apache License, Version 2.0 (the "License"). You may not use
+# this file except in compliance with the License. A copy of the License is
+# located at
+#
+#     http://aws.amazon.com/apache2.0/
+#
+# or in the "license" file accompanying this file. This file is distributed on an
+# "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or
+# implied. See the License for the specific language governing permissions and
+# limitations under the License.
+
+# Expected runtime is less than 20 seconds.
+
+CBMCFLAGS +=
+
+PROOF_UID = s2n_array_init
+HARNESS_ENTRY = $(PROOF_UID)_harness
+HARNESS_FILE = $(HARNESS_ENTRY).c
+
+PROOF_SOURCES += $(PROOFDIR)/$(HARNESS_FILE)
+PROOF_SOURCES += $(PROOF_SOURCE)/cbmc_utils.c
+PROOF_SOURCES += $(PROOF_SOURCE)/make_common_datastructures.c
+PROOF_SOURCES += $(PROOF_STUB)/mlock.c
+PROOF_SOURCES += $(PROOF_STUB)/munlock.c
+PROOF_SOURCES += $(PROOF_STUB)/s2n_calculate_stacktrace.c
+PROOF_SOURCES += $(PROOF_STUB)/sysconf.c
+
+PROJECT_SOURCES += $(SRCDIR)/utils/s2n_result.c
+PROJECT_SOURCES += $(SRCDIR)/utils/s2n_array.c
+PROJECT_SOURCES += $(SRCDIR)/utils/s2n_blob.c
+PROJECT_SOURCES += $(SRCDIR)/utils/s2n_mem.c
+PROJECT_SOURCES += $(SRCDIR)/utils/s2n_safety.c
+
+# We abstract these functions because manual inspection demonstrates they are unreachable.
+REMOVE_FUNCTION_BODY += s2n_blob_slice
+REMOVE_FUNCTION_BODY += s2n_ensure_memcpy_trace
+REMOVE_FUNCTION_BODY += __CPROVER_file_local_s2n_mem_c_s2n_mem_cleanup_impl
+
+UNWINDSET +=
+
+include ../Makefile.common

--- a/tests/cbmc/proofs/s2n_array_insert/Makefile
+++ b/tests/cbmc/proofs/s2n_array_insert/Makefile
@@ -1,4 +1,3 @@
-# Copyright Amazon.com, Inc. or its affiliates. All Rights Reserved.
 #
 # Licensed under the Apache License, Version 2.0 (the "License"). You may not use
 # this file except in compliance with the License. A copy of the License is

--- a/tests/cbmc/proofs/s2n_array_insert/Makefile.backup
+++ b/tests/cbmc/proofs/s2n_array_insert/Makefile.backup
@@ -1,0 +1,54 @@
+# Copyright Amazon.com, Inc. or its affiliates. All Rights Reserved.
+#
+# Licensed under the Apache License, Version 2.0 (the "License"). You may not use
+# this file except in compliance with the License. A copy of the License is
+# located at
+#
+#     http://aws.amazon.com/apache2.0/
+#
+# or in the "license" file accompanying this file. This file is distributed on an
+# "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or
+# implied. See the License for the specific language governing permissions and
+# limitations under the License.
+
+# Expected runtime is less than 10 seconds.
+
+MAX_ARRAY_LEN = 10
+DEFINES += -DMAX_ARRAY_LEN=$(MAX_ARRAY_LEN)
+
+MAX_ARRAY_ELEMENT_SIZE = 10
+DEFINES += -DMAX_ARRAY_ELEMENT_SIZE=$(MAX_ARRAY_ELEMENT_SIZE)
+
+DEFINES += -DMADV_DONTDUMP=1
+
+CBMCFLAGS +=
+
+PROOF_UID = s2n_array_insert
+HARNESS_ENTRY = $(PROOF_UID)_harness
+HARNESS_FILE = $(HARNESS_ENTRY).c
+
+PROOF_SOURCES += $(PROOFDIR)/$(HARNESS_FILE)
+PROOF_SOURCES += $(PROOF_SOURCE)/cbmc_utils.c
+PROOF_SOURCES += $(PROOF_SOURCE)/make_common_datastructures.c
+PROOF_SOURCES += $(PROOF_STUB)/madvise.c
+PROOF_SOURCES += $(PROOF_STUB)/memmove_havoc.c
+PROOF_SOURCES += $(PROOF_STUB)/mlock.c
+PROOF_SOURCES += $(PROOF_STUB)/munlock.c
+PROOF_SOURCES += $(PROOF_STUB)/posix_memalign_override.c
+PROOF_SOURCES += $(PROOF_STUB)/s2n_calculate_stacktrace.c
+PROOF_SOURCES += $(PROOF_STUB)/s2n_ensure.c
+PROOF_SOURCES += $(PROOF_STUB)/sysconf.c
+
+PROJECT_SOURCES += $(SRCDIR)/utils/s2n_array.c
+PROJECT_SOURCES += $(SRCDIR)/utils/s2n_blob.c
+PROJECT_SOURCES += $(SRCDIR)/utils/s2n_mem.c
+PROJECT_SOURCES += $(SRCDIR)/utils/s2n_result.c
+PROJECT_SOURCES += $(SRCDIR)/utils/s2n_safety.c
+
+# We abstract this function because manual inspection demonstrates it is unreachable.
+REMOVE_FUNCTION_BODY += s2n_blob_slice
+REMOVE_FUNCTION_BODY += __CPROVER_file_local_s2n_mem_c_s2n_mem_cleanup_impl
+
+UNWINDSET +=
+
+include ../Makefile.common

--- a/tests/cbmc/proofs/s2n_array_insert_and_copy/Makefile
+++ b/tests/cbmc/proofs/s2n_array_insert_and_copy/Makefile
@@ -1,4 +1,3 @@
-# Copyright Amazon.com, Inc. or its affiliates. All Rights Reserved.
 #
 # Licensed under the Apache License, Version 2.0 (the "License"). You may not use
 # this file except in compliance with the License. A copy of the License is

--- a/tests/cbmc/proofs/s2n_array_insert_and_copy/Makefile.backup
+++ b/tests/cbmc/proofs/s2n_array_insert_and_copy/Makefile.backup
@@ -1,0 +1,54 @@
+# Copyright Amazon.com, Inc. or its affiliates. All Rights Reserved.
+#
+# Licensed under the Apache License, Version 2.0 (the "License"). You may not use
+# this file except in compliance with the License. A copy of the License is
+# located at
+#
+#     http://aws.amazon.com/apache2.0/
+#
+# or in the "license" file accompanying this file. This file is distributed on an
+# "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or
+# implied. See the License for the specific language governing permissions and
+# limitations under the License.
+
+# Expected runtime is less than 10 seconds.
+
+MAX_ARRAY_LEN = 10
+DEFINES += -DMAX_ARRAY_LEN=$(MAX_ARRAY_LEN)
+
+MAX_ARRAY_ELEMENT_SIZE = 10
+DEFINES += -DMAX_ARRAY_ELEMENT_SIZE=$(MAX_ARRAY_ELEMENT_SIZE)
+
+DEFINES += -DMADV_DONTDUMP=1
+
+CBMCFLAGS +=
+
+PROOF_UID = s2n_array_insert_and_copy
+HARNESS_ENTRY = $(PROOF_UID)_harness
+HARNESS_FILE = $(HARNESS_ENTRY).c
+
+PROOF_SOURCES += $(PROOFDIR)/$(HARNESS_FILE)
+PROOF_SOURCES += $(PROOF_SOURCE)/cbmc_utils.c
+PROOF_SOURCES += $(PROOF_SOURCE)/make_common_datastructures.c
+PROOF_SOURCES += $(PROOF_STUB)/madvise.c
+PROOF_SOURCES += $(PROOF_STUB)/memmove_havoc.c
+PROOF_SOURCES += $(PROOF_STUB)/mlock.c
+PROOF_SOURCES += $(PROOF_STUB)/munlock.c
+PROOF_SOURCES += $(PROOF_STUB)/posix_memalign_override.c
+PROOF_SOURCES += $(PROOF_STUB)/s2n_calculate_stacktrace.c
+PROOF_SOURCES += $(PROOF_STUB)/s2n_ensure.c
+PROOF_SOURCES += $(PROOF_STUB)/sysconf.c
+
+PROJECT_SOURCES += $(SRCDIR)/utils/s2n_array.c
+PROJECT_SOURCES += $(SRCDIR)/utils/s2n_blob.c
+PROJECT_SOURCES += $(SRCDIR)/utils/s2n_mem.c
+PROJECT_SOURCES += $(SRCDIR)/utils/s2n_result.c
+PROJECT_SOURCES += $(SRCDIR)/utils/s2n_safety.c
+
+# We abstract this function because manual inspection demonstrates it is unreachable.
+REMOVE_FUNCTION_BODY += s2n_blob_slice
+REMOVE_FUNCTION_BODY += __CPROVER_file_local_s2n_mem_c_s2n_mem_cleanup_impl
+
+UNWINDSET +=
+
+include ../Makefile.common

--- a/tests/cbmc/proofs/s2n_array_new/Makefile
+++ b/tests/cbmc/proofs/s2n_array_new/Makefile
@@ -1,4 +1,3 @@
-# Copyright Amazon.com, Inc. or its affiliates. All Rights Reserved.
 #
 # Licensed under the Apache License, Version 2.0 (the "License"). You may not use
 # this file except in compliance with the License. A copy of the License is

--- a/tests/cbmc/proofs/s2n_array_new/Makefile.backup
+++ b/tests/cbmc/proofs/s2n_array_new/Makefile.backup
@@ -1,0 +1,46 @@
+# Copyright Amazon.com, Inc. or its affiliates. All Rights Reserved.
+#
+# Licensed under the Apache License, Version 2.0 (the "License"). You may not use
+# this file except in compliance with the License. A copy of the License is
+# located at
+#
+#     http://aws.amazon.com/apache2.0/
+#
+# or in the "license" file accompanying this file. This file is distributed on an
+# "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or
+# implied. See the License for the specific language governing permissions and
+# limitations under the License.
+
+# Expected runtime is less than 20 seconds.
+
+CBMCFLAGS +=
+
+PROOF_UID = s2n_array_new
+HARNESS_ENTRY = $(PROOF_UID)_harness
+HARNESS_FILE = $(HARNESS_ENTRY).c
+
+PROOF_SOURCES += $(PROOFDIR)/$(HARNESS_FILE)
+PROOF_SOURCES += $(PROOF_SOURCE)/cbmc_utils.c
+PROOF_SOURCES += $(PROOF_SOURCE)/make_common_datastructures.c
+PROOF_SOURCES += $(PROOF_STUB)/memset_havoc.c
+PROOF_SOURCES += $(PROOF_STUB)/mlock.c
+PROOF_SOURCES += $(PROOF_STUB)/munlock.c
+PROOF_SOURCES += $(PROOF_STUB)/posix_memalign_override.c
+PROOF_SOURCES += $(PROOF_STUB)/s2n_calculate_stacktrace.c
+PROOF_SOURCES += $(PROOF_STUB)/sysconf.c
+
+PROJECT_SOURCES += $(SRCDIR)/utils/s2n_result.c
+PROJECT_SOURCES += $(SRCDIR)/utils/s2n_array.c
+PROJECT_SOURCES += $(SRCDIR)/utils/s2n_blob.c
+PROJECT_SOURCES += $(SRCDIR)/utils/s2n_ensure.c
+PROJECT_SOURCES += $(SRCDIR)/utils/s2n_mem.c
+PROJECT_SOURCES += $(SRCDIR)/utils/s2n_safety.c
+
+# We abstract these functions because manual inspection demonstrates they are unreachable.
+REMOVE_FUNCTION_BODY += s2n_blob_slice
+REMOVE_FUNCTION_BODY += s2n_ensure_memcpy_trace
+REMOVE_FUNCTION_BODY += __CPROVER_file_local_s2n_mem_c_s2n_mem_cleanup_impl
+
+UNWINDSET +=
+
+include ../Makefile.common

--- a/tests/cbmc/proofs/s2n_array_num_elements/Makefile
+++ b/tests/cbmc/proofs/s2n_array_num_elements/Makefile
@@ -1,4 +1,3 @@
-# Copyright Amazon.com, Inc. or its affiliates. All Rights Reserved.
 #
 # Licensed under the Apache License, Version 2.0 (the "License"). You may not use
 # this file except in compliance with the License. A copy of the License is

--- a/tests/cbmc/proofs/s2n_array_num_elements/Makefile.backup
+++ b/tests/cbmc/proofs/s2n_array_num_elements/Makefile.backup
@@ -1,0 +1,39 @@
+# Copyright Amazon.com, Inc. or its affiliates. All Rights Reserved.
+#
+# Licensed under the Apache License, Version 2.0 (the "License"). You may not use
+# this file except in compliance with the License. A copy of the License is
+# located at
+#
+#     http://aws.amazon.com/apache2.0/
+#
+# or in the "license" file accompanying this file. This file is distributed on an
+# "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or
+# implied. See the License for the specific language governing permissions and
+# limitations under the License.
+
+# Expected runtime is less than 10 seconds.
+
+MAX_ARRAY_LEN = 100
+DEFINES += -DMAX_ARRAY_LEN=$(MAX_ARRAY_LEN)
+
+MAX_ARRAY_ELEMENT_SIZE = 100
+DEFINES += -DMAX_ARRAY_ELEMENT_SIZE=$(MAX_ARRAY_ELEMENT_SIZE)
+
+CBMCFLAGS +=
+
+PROOF_UID = s2n_array_num_elements
+HARNESS_ENTRY = $(PROOF_UID)_harness
+HARNESS_FILE = $(HARNESS_ENTRY).c
+
+PROOF_SOURCES += $(PROOFDIR)/$(HARNESS_FILE)
+PROOF_SOURCES += $(PROOF_SOURCE)/make_common_datastructures.c
+PROOF_SOURCES += $(PROOF_STUB)/s2n_calculate_stacktrace.c
+
+PROJECT_SOURCES += $(SRCDIR)/utils/s2n_array.c
+PROJECT_SOURCES += $(SRCDIR)/utils/s2n_blob.c
+PROJECT_SOURCES += $(SRCDIR)/utils/s2n_result.c
+PROJECT_SOURCES += $(SRCDIR)/utils/s2n_safety.c
+
+UNWINDSET +=
+
+include ../Makefile.common

--- a/tests/cbmc/proofs/s2n_array_pushback/Makefile
+++ b/tests/cbmc/proofs/s2n_array_pushback/Makefile
@@ -1,4 +1,3 @@
-# Copyright Amazon.com, Inc. or its affiliates. All Rights Reserved.
 #
 # Licensed under the Apache License, Version 2.0 (the "License"). You may not use
 # this file except in compliance with the License. A copy of the License is

--- a/tests/cbmc/proofs/s2n_array_pushback/Makefile.backup
+++ b/tests/cbmc/proofs/s2n_array_pushback/Makefile.backup
@@ -1,0 +1,54 @@
+# Copyright Amazon.com, Inc. or its affiliates. All Rights Reserved.
+#
+# Licensed under the Apache License, Version 2.0 (the "License"). You may not use
+# this file except in compliance with the License. A copy of the License is
+# located at
+#
+#     http://aws.amazon.com/apache2.0/
+#
+# or in the "license" file accompanying this file. This file is distributed on an
+# "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or
+# implied. See the License for the specific language governing permissions and
+# limitations under the License.
+
+# Expected runtime is less than 25 seconds.
+
+MAX_ARRAY_LEN = 10
+DEFINES += -DMAX_ARRAY_LEN=$(MAX_ARRAY_LEN)
+
+MAX_ARRAY_ELEMENT_SIZE = 10
+DEFINES += -DMAX_ARRAY_ELEMENT_SIZE=$(MAX_ARRAY_ELEMENT_SIZE)
+
+DEFINES += -DMADV_DONTDUMP=1
+
+CBMCFLAGS +=
+
+PROOF_UID = s2n_array_pushback
+HARNESS_ENTRY = $(PROOF_UID)_harness
+HARNESS_FILE = $(HARNESS_ENTRY).c
+
+PROOF_SOURCES += $(PROOFDIR)/$(HARNESS_FILE)
+PROOF_SOURCES += $(PROOF_SOURCE)/cbmc_utils.c
+PROOF_SOURCES += $(PROOF_SOURCE)/make_common_datastructures.c
+PROOF_SOURCES += $(PROOF_STUB)/madvise.c
+PROOF_SOURCES += $(PROOF_STUB)/memmove_havoc.c
+PROOF_SOURCES += $(PROOF_STUB)/mlock.c
+PROOF_SOURCES += $(PROOF_STUB)/munlock.c
+PROOF_SOURCES += $(PROOF_STUB)/posix_memalign_override.c
+PROOF_SOURCES += $(PROOF_STUB)/s2n_calculate_stacktrace.c
+PROOF_SOURCES += $(PROOF_STUB)/s2n_ensure.c
+PROOF_SOURCES += $(PROOF_STUB)/sysconf.c
+
+PROJECT_SOURCES += $(SRCDIR)/utils/s2n_array.c
+PROJECT_SOURCES += $(SRCDIR)/utils/s2n_blob.c
+PROJECT_SOURCES += $(SRCDIR)/utils/s2n_mem.c
+PROJECT_SOURCES += $(SRCDIR)/utils/s2n_result.c
+PROJECT_SOURCES += $(SRCDIR)/utils/s2n_safety.c
+
+# We abstract this function because manual inspection demonstrates it is unreachable.
+REMOVE_FUNCTION_BODY += s2n_blob_slice
+REMOVE_FUNCTION_BODY += __CPROVER_file_local_s2n_mem_c_s2n_mem_cleanup_impl
+
+UNWINDSET +=
+
+include ../Makefile.common

--- a/tests/cbmc/proofs/s2n_array_remove/Makefile
+++ b/tests/cbmc/proofs/s2n_array_remove/Makefile
@@ -1,4 +1,3 @@
-# Copyright Amazon.com, Inc. or its affiliates. All Rights Reserved.
 #
 # Licensed under the Apache License, Version 2.0 (the "License"). You may not use
 # this file except in compliance with the License. A copy of the License is

--- a/tests/cbmc/proofs/s2n_array_remove/Makefile.backup
+++ b/tests/cbmc/proofs/s2n_array_remove/Makefile.backup
@@ -1,0 +1,44 @@
+# Copyright Amazon.com, Inc. or its affiliates. All Rights Reserved.
+#
+# Licensed under the Apache License, Version 2.0 (the "License"). You may not use
+# this file except in compliance with the License. A copy of the License is
+# located at
+#
+#     http://aws.amazon.com/apache2.0/
+#
+# or in the "license" file accompanying this file. This file is distributed on an
+# "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or
+# implied. See the License for the specific language governing permissions and
+# limitations under the License.
+
+# Expected runtime is less than 10 seconds.
+
+MAX_ARRAY_LEN = 10
+DEFINES += -DMAX_ARRAY_LEN=$(MAX_ARRAY_LEN)
+
+MAX_ARRAY_ELEMENT_SIZE = 10
+DEFINES += -DMAX_ARRAY_ELEMENT_SIZE=$(MAX_ARRAY_ELEMENT_SIZE)
+
+CBMCFLAGS +=
+
+PROOF_UID = s2n_array_remove
+HARNESS_ENTRY = $(PROOF_UID)_harness
+HARNESS_FILE = $(HARNESS_ENTRY).c
+
+PROOF_SOURCES += $(PROOFDIR)/$(HARNESS_FILE)
+PROOF_SOURCES += $(PROOF_SOURCE)/cbmc_utils.c
+PROOF_SOURCES += $(PROOF_SOURCE)/make_common_datastructures.c
+PROOF_SOURCES += $(PROOF_STUB)/memmove_havoc.c
+PROOF_SOURCES += $(PROOF_STUB)/mlock.c
+PROOF_SOURCES += $(PROOF_STUB)/munlock.c
+PROOF_SOURCES += $(PROOF_STUB)/s2n_calculate_stacktrace.c
+PROOF_SOURCES += $(PROOF_STUB)/sysconf.c
+
+PROJECT_SOURCES += $(SRCDIR)/utils/s2n_array.c
+PROJECT_SOURCES += $(SRCDIR)/utils/s2n_blob.c
+PROJECT_SOURCES += $(SRCDIR)/utils/s2n_result.c
+PROJECT_SOURCES += $(SRCDIR)/utils/s2n_safety.c
+
+UNWINDSET +=
+
+include ../Makefile.common

--- a/tests/cbmc/proofs/s2n_blob_char_to_lower/Makefile
+++ b/tests/cbmc/proofs/s2n_blob_char_to_lower/Makefile
@@ -1,4 +1,3 @@
-# Copyright Amazon.com, Inc. or its affiliates. All Rights Reserved.
 #
 # Licensed under the Apache License, Version 2.0 (the "License"). You may not use
 # this file except in compliance with the License. A copy of the License is

--- a/tests/cbmc/proofs/s2n_blob_char_to_lower/Makefile.backup
+++ b/tests/cbmc/proofs/s2n_blob_char_to_lower/Makefile.backup
@@ -1,0 +1,39 @@
+# Copyright Amazon.com, Inc. or its affiliates. All Rights Reserved.
+#
+# Licensed under the Apache License, Version 2.0 (the "License"). You may not use
+# this file except in compliance with the License. A copy of the License is
+# located at
+#
+#     http://aws.amazon.com/apache2.0/
+#
+# or in the "license" file accompanying this file. This file is distributed on an
+# "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or
+# implied. See the License for the specific language governing permissions and
+# limitations under the License.
+
+
+# Enough to get full coverage with 10 seconds of runtime.
+MAX_BLOB_SIZE = 10
+DEFINES += -DMAX_BLOB_SIZE=$(MAX_BLOB_SIZE)
+
+CBMCFLAGS +=
+
+PROOF_UID = s2n_blob_char_to_lower
+HARNESS_ENTRY = $(PROOF_UID)_harness
+HARNESS_FILE = $(HARNESS_ENTRY).c
+
+PROOF_SOURCES += $(PROOFDIR)/$(HARNESS_FILE)
+PROOF_SOURCES += $(PROOF_SOURCE)/cbmc_utils.c
+PROOF_SOURCES += $(PROOF_SOURCE)/make_common_datastructures.c
+
+PROJECT_SOURCES += $(SRCDIR)/utils/s2n_blob.c
+PROJECT_SOURCES += $(SRCDIR)/utils/s2n_safety.c
+PROJECT_SOURCES += $(SRCDIR)/error/s2n_errno.c
+PROJECT_SOURCES += $(SRCDIR)/utils/s2n_result.c
+
+# We abstract this function because manual inspection demonstrates it is unreachable.
+REMOVE_FUNCTION_BODY += s2n_calculate_stacktrace
+
+UNWINDSET += s2n_blob_char_to_lower.1:$(call addone,$(MAX_BLOB_SIZE))
+
+include ../Makefile.common

--- a/tests/cbmc/proofs/s2n_blob_init/Makefile
+++ b/tests/cbmc/proofs/s2n_blob_init/Makefile
@@ -1,4 +1,3 @@
-# Copyright Amazon.com, Inc. or its affiliates. All Rights Reserved.
 #
 # Licensed under the Apache License, Version 2.0 (the "License"). You may not use
 # this file except in compliance with the License. A copy of the License is

--- a/tests/cbmc/proofs/s2n_blob_init/Makefile.backup
+++ b/tests/cbmc/proofs/s2n_blob_init/Makefile.backup
@@ -1,0 +1,29 @@
+# Copyright Amazon.com, Inc. or its affiliates. All Rights Reserved.
+#
+# Licensed under the Apache License, Version 2.0 (the "License"). You may not use
+# this file except in compliance with the License. A copy of the License is
+# located at
+#
+#     http://aws.amazon.com/apache2.0/
+#
+# or in the "license" file accompanying this file. This file is distributed on an
+# "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or
+# implied. See the License for the specific language governing permissions and
+# limitations under the License.
+
+# Use the default set of CBMC flags.
+CBMCFLAGS +=
+
+PROOF_UID = s2n_blob_init
+HARNESS_ENTRY = $(PROOF_UID)_harness
+HARNESS_FILE = $(HARNESS_ENTRY).c
+
+PROOF_SOURCES += $(PROOFDIR)/$(HARNESS_FILE)
+PROOF_SOURCES += $(PROOF_SOURCE)/make_common_datastructures.c
+
+PROJECT_SOURCES += $(SRCDIR)/utils/s2n_blob.c
+PROJECT_SOURCES += $(SRCDIR)/utils/s2n_result.c
+
+UNWINDSET +=
+
+include ../Makefile.common

--- a/tests/cbmc/proofs/s2n_blob_is_growable/Makefile
+++ b/tests/cbmc/proofs/s2n_blob_is_growable/Makefile
@@ -1,4 +1,3 @@
-# Copyright Amazon.com, Inc. or its affiliates. All Rights Reserved.
 #
 # Licensed under the Apache License, Version 2.0 (the "License"). You may not use
 # this file except in compliance with the License. A copy of the License is

--- a/tests/cbmc/proofs/s2n_blob_is_growable/Makefile.backup
+++ b/tests/cbmc/proofs/s2n_blob_is_growable/Makefile.backup
@@ -1,0 +1,30 @@
+# Copyright Amazon.com, Inc. or its affiliates. All Rights Reserved.
+#
+# Licensed under the Apache License, Version 2.0 (the "License"). You may not use
+# this file except in compliance with the License. A copy of the License is
+# located at
+#
+#     http://aws.amazon.com/apache2.0/
+#
+# or in the "license" file accompanying this file. This file is distributed on an
+# "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or
+# implied. See the License for the specific language governing permissions and
+# limitations under the License.
+
+CBMCFLAGS +=
+
+PROOF_UID = s2n_blob_is_growable
+HARNESS_ENTRY = $(PROOF_UID)_harness
+HARNESS_FILE = $(HARNESS_ENTRY).c
+
+PROOF_SOURCES += $(PROOFDIR)/$(HARNESS_FILE)
+PROOF_SOURCES += $(PROOF_SOURCE)/make_common_datastructures.c
+PROOF_SOURCES += $(PROOF_STUB)/s2n_calculate_stacktrace.c
+
+PROJECT_SOURCES += $(SRCDIR)/utils/s2n_blob.c
+PROJECT_SOURCES += $(SRCDIR)/utils/s2n_mem.c
+PROJECT_SOURCES += $(SRCDIR)/utils/s2n_result.c
+
+UNWINDSET +=
+
+include ../Makefile.common

--- a/tests/cbmc/proofs/s2n_blob_slice/Makefile
+++ b/tests/cbmc/proofs/s2n_blob_slice/Makefile
@@ -1,4 +1,3 @@
-# Copyright Amazon.com, Inc. or its affiliates. All Rights Reserved.
 #
 # Licensed under the Apache License, Version 2.0 (the "License"). You may not use
 # this file except in compliance with the License. A copy of the License is

--- a/tests/cbmc/proofs/s2n_blob_slice/Makefile.backup
+++ b/tests/cbmc/proofs/s2n_blob_slice/Makefile.backup
@@ -1,0 +1,35 @@
+# Copyright Amazon.com, Inc. or its affiliates. All Rights Reserved.
+#
+# Licensed under the Apache License, Version 2.0 (the "License"). You may not use
+# this file except in compliance with the License. A copy of the License is
+# located at
+#
+#     http://aws.amazon.com/apache2.0/
+#
+# or in the "license" file accompanying this file. This file is distributed on an
+# "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or
+# implied. See the License for the specific language governing permissions and
+# limitations under the License.
+
+# Expected runtime is 10 seconds.
+CBMCFLAGS +=
+
+PROOF_UID = s2n_blob_slice
+HARNESS_ENTRY = $(PROOF_UID)_harness
+HARNESS_FILE = $(HARNESS_ENTRY).c
+
+PROOF_SOURCES += $(PROOFDIR)/$(HARNESS_FILE)
+PROOF_SOURCES += $(PROOF_SOURCE)/cbmc_utils.c
+PROOF_SOURCES += $(PROOF_SOURCE)/make_common_datastructures.c
+
+PROJECT_SOURCES += $(SRCDIR)/utils/s2n_blob.c
+PROJECT_SOURCES += $(SRCDIR)/error/s2n_errno.c
+PROJECT_SOURCES += $(SRCDIR)/utils/s2n_safety.c
+PROJECT_SOURCES += $(SRCDIR)/utils/s2n_result.c
+
+# We abstract this function because manual inspection demonstrates it is unreachable.
+REMOVE_FUNCTION_BODY += s2n_calculate_stacktrace
+
+UNWINDSET +=
+
+include ../Makefile.common

--- a/tests/cbmc/proofs/s2n_blob_zero/Makefile
+++ b/tests/cbmc/proofs/s2n_blob_zero/Makefile
@@ -1,4 +1,3 @@
-# Copyright Amazon.com, Inc. or its affiliates. All Rights Reserved.
 #
 # Licensed under the Apache License, Version 2.0 (the "License"). You may not use
 # this file except in compliance with the License. A copy of the License is

--- a/tests/cbmc/proofs/s2n_blob_zero/Makefile.backup
+++ b/tests/cbmc/proofs/s2n_blob_zero/Makefile.backup
@@ -1,0 +1,32 @@
+# Copyright Amazon.com, Inc. or its affiliates. All Rights Reserved.
+#
+# Licensed under the Apache License, Version 2.0 (the "License"). You may not use
+# this file except in compliance with the License. A copy of the License is
+# located at
+#
+#     http://aws.amazon.com/apache2.0/
+#
+# or in the "license" file accompanying this file. This file is distributed on an
+# "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or
+# implied. See the License for the specific language governing permissions and
+# limitations under the License.
+
+# Expected runtime is 10 seconds.
+
+CBMCFLAGS +=
+
+PROOF_UID = s2n_blob_zero
+HARNESS_ENTRY = $(PROOF_UID)_harness
+HARNESS_FILE = $(HARNESS_ENTRY).c
+
+PROOF_SOURCES += $(PROOFDIR)/$(HARNESS_FILE)
+PROOF_SOURCES += $(PROOF_SOURCE)/cbmc_utils.c
+PROOF_SOURCES += $(PROOF_SOURCE)/make_common_datastructures.c
+
+PROJECT_SOURCES += $(SRCDIR)/utils/s2n_blob.c
+PROJECT_SOURCES += $(SRCDIR)/utils/s2n_ensure.c
+PROJECT_SOURCES += $(SRCDIR)/utils/s2n_result.c
+
+UNWINDSET +=
+
+include ../Makefile.common

--- a/tests/cbmc/proofs/s2n_blob_zeroize_free/Makefile
+++ b/tests/cbmc/proofs/s2n_blob_zeroize_free/Makefile
@@ -1,4 +1,3 @@
-# Copyright Amazon.com, Inc. or its affiliates. All Rights Reserved.
 #
 # Licensed under the Apache License, Version 2.0 (the "License"). You may not use
 # this file except in compliance with the License. A copy of the License is

--- a/tests/cbmc/proofs/s2n_blob_zeroize_free/Makefile.backup
+++ b/tests/cbmc/proofs/s2n_blob_zeroize_free/Makefile.backup
@@ -1,0 +1,37 @@
+# Copyright Amazon.com, Inc. or its affiliates. All Rights Reserved.
+#
+# Licensed under the Apache License, Version 2.0 (the "License"). You may not use
+# this file except in compliance with the License. A copy of the License is
+# located at
+#
+#     http://aws.amazon.com/apache2.0/
+#
+# or in the "license" file accompanying this file. This file is distributed on an
+# "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or
+# implied. See the License for the specific language governing permissions and
+# limitations under the License.
+#
+# Expected runtime is around 5 seconds.
+
+CHECKFLAGS += --memory-leak-check
+
+PROOF_UID = s2n_blob_zeroize_free
+HARNESS_ENTRY = $(PROOF_UID)_harness
+HARNESS_FILE = $(HARNESS_ENTRY).c
+
+PROOF_SOURCES += $(PROOFDIR)/$(HARNESS_FILE)
+PROOF_SOURCES += $(PROOF_SOURCE)/cbmc_utils.c
+PROOF_SOURCES += $(PROOF_SOURCE)/make_common_datastructures.c
+PROOF_SOURCES += $(PROOF_STUB)/munlock.c
+PROOF_SOURCES += $(PROOF_STUB)/s2n_calculate_stacktrace.c
+PROOF_SOURCES += $(PROOF_STUB)/sysconf.c
+
+PROJECT_SOURCES += $(SRCDIR)/utils/s2n_blob.c
+PROJECT_SOURCES += $(SRCDIR)/utils/s2n_mem.c
+PROJECT_SOURCES += $(SRCDIR)/utils/s2n_result.c
+
+REMOVE_FUNCTION_BODY += __CPROVER_file_local_s2n_mem_c_s2n_mem_cleanup_impl
+
+UNWINDSET +=
+
+include ../Makefile.common

--- a/tests/cbmc/proofs/s2n_connection_get_last_message_name/Makefile
+++ b/tests/cbmc/proofs/s2n_connection_get_last_message_name/Makefile
@@ -1,4 +1,3 @@
-# Copyright Amazon.com, Inc. or its affiliates. All Rights Reserved.
 #
 # Licensed under the Apache License, Version 2.0 (the "License"). You may not use
 # this file except in compliance with the License. A copy of the License is

--- a/tests/cbmc/proofs/s2n_connection_get_last_message_name/Makefile.backup
+++ b/tests/cbmc/proofs/s2n_connection_get_last_message_name/Makefile.backup
@@ -1,0 +1,30 @@
+# Copyright Amazon.com, Inc. or its affiliates. All Rights Reserved.
+#
+# Licensed under the Apache License, Version 2.0 (the "License"). You may not use
+# this file except in compliance with the License. A copy of the License is
+# located at
+#
+#     http://aws.amazon.com/apache2.0/
+#
+# or in the "license" file accompanying this file. This file is distributed on an
+# "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or
+# implied. See the License for the specific language governing permissions and
+# limitations under the License.
+
+# Use the default set of CBMC flags.
+CBMCFLAGS +=
+
+PROOF_UID = s2n_connection_get_last_message_name
+HARNESS_ENTRY = $(PROOF_UID)_harness
+HARNESS_FILE = $(HARNESS_ENTRY).c
+
+PROOF_SOURCES += $(PROOFDIR)/$(HARNESS_FILE)
+PROOF_SOURCES += $(PROOF_STUB)/s2n_calculate_stacktrace.c
+
+PROJECT_SOURCES += $(SRCDIR)/tls/s2n_handshake_io.c
+PROJECT_SOURCES += $(SRCDIR)/tls/s2n_handshake.c
+PROJECT_SOURCES += $(SRCDIR)/utils/s2n_result.c
+
+UNWINDSET +=
+
+include ../Makefile.common

--- a/tests/cbmc/proofs/s2n_constant_time_copy_or_dont/Makefile
+++ b/tests/cbmc/proofs/s2n_constant_time_copy_or_dont/Makefile
@@ -1,4 +1,3 @@
-# Copyright Amazon.com, Inc. or its affiliates. All Rights Reserved.
 #
 # Licensed under the Apache License, Version 2.0 (the "License"). You may not use
 # this file except in compliance with the License. A copy of the License is

--- a/tests/cbmc/proofs/s2n_constant_time_copy_or_dont/Makefile.backup
+++ b/tests/cbmc/proofs/s2n_constant_time_copy_or_dont/Makefile.backup
@@ -1,0 +1,31 @@
+# Copyright Amazon.com, Inc. or its affiliates. All Rights Reserved.
+#
+# Licensed under the Apache License, Version 2.0 (the "License"). You may not use
+# this file except in compliance with the License. A copy of the License is
+# located at
+#
+#     http://aws.amazon.com/apache2.0/
+#
+# or in the "license" file accompanying this file. This file is distributed on an
+# "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or
+# implied. See the License for the specific language governing permissions and
+# limitations under the License.
+
+# Expected runtime is 10 seconds.
+
+MAX_ARR_LEN = 10
+DEFINES += -DMAX_ARR_LEN=$(MAX_ARR_LEN)
+
+CBMCFLAGS +=
+
+PROOF_UID = s2n_constant_time_copy_or_dont
+HARNESS_ENTRY = $(PROOF_UID)_harness
+HARNESS_FILE = $(HARNESS_ENTRY).c
+
+PROOF_SOURCES += $(PROOFDIR)/$(HARNESS_FILE)
+
+PROJECT_SOURCES += $(SRCDIR)/utils/s2n_safety.c
+
+UNWINDSET += s2n_constant_time_copy_or_dont.0:$(call addone,$(MAX_ARR_LEN))
+
+include ../Makefile.common

--- a/tests/cbmc/proofs/s2n_constant_time_equals/Makefile
+++ b/tests/cbmc/proofs/s2n_constant_time_equals/Makefile
@@ -1,4 +1,3 @@
-# Copyright Amazon.com, Inc. or its affiliates. All Rights Reserved.
 #
 # Licensed under the Apache License, Version 2.0 (the "License"). You may not use
 # this file except in compliance with the License. A copy of the License is

--- a/tests/cbmc/proofs/s2n_constant_time_equals/Makefile.backup
+++ b/tests/cbmc/proofs/s2n_constant_time_equals/Makefile.backup
@@ -1,0 +1,31 @@
+# Copyright Amazon.com, Inc. or its affiliates. All Rights Reserved.
+#
+# Licensed under the Apache License, Version 2.0 (the "License"). You may not use
+# this file except in compliance with the License. A copy of the License is
+# located at
+#
+#     http://aws.amazon.com/apache2.0/
+#
+# or in the "license" file accompanying this file. This file is distributed on an
+# "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or
+# implied. See the License for the specific language governing permissions and
+# limitations under the License.
+
+
+# Expected runtime is 6 seconds.
+MAX_ARR_LEN = 10
+DEFINES += -DMAX_ARR_LEN=$(MAX_ARR_LEN)
+
+CBMCFLAGS +=
+
+PROOF_UID = s2n_constant_time_equals
+HARNESS_ENTRY = $(PROOF_UID)_harness
+HARNESS_FILE = $(HARNESS_ENTRY).c
+
+PROOF_SOURCES += $(PROOFDIR)/$(HARNESS_FILE)
+
+PROJECT_SOURCES += $(SRCDIR)/utils/s2n_safety.c
+
+UNWINDSET += s2n_constant_time_equals.0:$(call addone,$(MAX_ARR_LEN))
+
+include ../Makefile.common

--- a/tests/cbmc/proofs/s2n_constant_time_pkcs1_unpad_or_dont/Makefile
+++ b/tests/cbmc/proofs/s2n_constant_time_pkcs1_unpad_or_dont/Makefile
@@ -1,4 +1,3 @@
-# Copyright Amazon.com, Inc. or its affiliates. All Rights Reserved.
 #
 # Licensed under the Apache License, Version 2.0 (the "License"). You may not use
 # this file except in compliance with the License. A copy of the License is

--- a/tests/cbmc/proofs/s2n_constant_time_pkcs1_unpad_or_dont/Makefile.backup
+++ b/tests/cbmc/proofs/s2n_constant_time_pkcs1_unpad_or_dont/Makefile.backup
@@ -1,0 +1,39 @@
+# Copyright Amazon.com, Inc. or its affiliates. All Rights Reserved.
+#
+# Licensed under the Apache License, Version 2.0 (the "License"). You may not use
+# this file except in compliance with the License. A copy of the License is
+# located at
+#
+#     http://aws.amazon.com/apache2.0/
+#
+# or in the "license" file accompanying this file. This file is distributed on an
+# "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or
+# implied. See the License for the specific language governing permissions and
+# limitations under the License.
+
+# Expected runtime is 10 seconds.
+
+MAX_ARR_LEN = 10
+
+# Bound for copy or dont must be at at least three higher than the maximum array length
+BOUND = $(MAX_ARR_LEN) + 3
+
+DEFINES += -DMAX_ARR_LEN=$(MAX_ARR_LEN)
+DEFINES += -DBOUND=$(BOUND)
+
+
+CBMCFLAGS +=
+
+PROOF_UID = s2n_constant_time_pkcs1_unpad_or_dont
+HARNESS_ENTRY = $(PROOF_UID)_harness
+HARNESS_FILE = $(HARNESS_ENTRY).c
+
+PROOF_SOURCES += $(PROOFDIR)/$(HARNESS_FILE)
+
+PROJECT_SOURCES += $(SRCDIR)/utils/s2n_safety.c
+
+UNWINDSET += s2n_constant_time_copy_or_dont.0:$(call addone,$(BOUND))
+UNWINDSET += s2n_constant_time_pkcs1_unpad_or_dont.0:$(call addone,$(MAX_ARR_LEN))
+UNWINDSET += s2n_constant_time_pkcs1_unpad_or_dont_harness.0:$(call addone,$(MAX_ARR_LEN))
+
+include ../Makefile.common

--- a/tests/cbmc/proofs/s2n_dh_compute_shared_secret_as_client/Makefile
+++ b/tests/cbmc/proofs/s2n_dh_compute_shared_secret_as_client/Makefile
@@ -1,4 +1,3 @@
-# Copyright Amazon.com, Inc. or its affiliates. All Rights Reserved.
 #
 # Licensed under the Apache License, Version 2.0 (the "License"). You may not use
 # this file except in compliance with the License. A copy of the License is

--- a/tests/cbmc/proofs/s2n_dh_compute_shared_secret_as_client/Makefile.backup
+++ b/tests/cbmc/proofs/s2n_dh_compute_shared_secret_as_client/Makefile.backup
@@ -1,0 +1,49 @@
+# Copyright Amazon.com, Inc. or its affiliates. All Rights Reserved.
+#
+# Licensed under the Apache License, Version 2.0 (the "License"). You may not use
+# this file except in compliance with the License. A copy of the License is
+# located at
+#
+#     http://aws.amazon.com/apache2.0/
+#
+# or in the "license" file accompanying this file. This file is distributed on an
+# "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or
+# implied. See the License for the specific language governing permissions and
+# limitations under the License.
+
+# Expected runtime is 2 minutes.
+
+CHECKFLAGS +=
+
+PROOF_UID = s2n_dh_compute_shared_secret_as_client
+HARNESS_ENTRY = $(PROOF_UID)_harness
+HARNESS_FILE = $(HARNESS_ENTRY).c
+
+PROOF_SOURCES += $(PROOFDIR)/$(HARNESS_FILE)
+PROOF_SOURCES += $(OPENSSL_SOURCE)/dh_override.c
+PROOF_SOURCES += $(OPENSSL_SOURCE)/bn_override.c
+PROOF_SOURCES += $(PROOF_SOURCE)/cbmc_utils.c
+PROOF_SOURCES += $(PROOF_SOURCE)/make_common_datastructures.c
+PROOF_SOURCES += $(PROOF_STUB)/mlock.c
+PROOF_SOURCES += $(PROOF_STUB)/munlock.c
+PROOF_SOURCES += $(PROOF_STUB)/posix_memalign_override.c
+PROOF_SOURCES += $(PROOF_STUB)/sysconf.c
+PROOF_SOURCES += $(PROOF_STUB)/s2n_calculate_stacktrace.c
+
+PROJECT_SOURCES += $(SRCDIR)/crypto/s2n_dhe.c
+PROJECT_SOURCES += $(SRCDIR)/stuffer/s2n_stuffer.c
+PROJECT_SOURCES += $(SRCDIR)/stuffer/s2n_stuffer_network_order.c
+PROJECT_SOURCES += $(SRCDIR)/utils/s2n_blob.c
+PROJECT_SOURCES += $(SRCDIR)/utils/s2n_ensure.c
+PROJECT_SOURCES += $(SRCDIR)/utils/s2n_mem.c
+PROJECT_SOURCES += $(SRCDIR)/utils/s2n_result.c
+PROJECT_SOURCES += $(SRCDIR)/utils/s2n_safety.c
+
+UNWINDSET += s2n_stuffer_write_network_order.4:9
+
+# We abstract this function because manual inspection demonstrates it is unreachable.
+REMOVE_FUNCTION_BODY += __CPROVER_file_local_s2n_mem_c_s2n_mem_cleanup_impl
+REMOVE_FUNCTION_BODY += s2n_stuffer_wipe
+REMOVE_FUNCTION_BODY += s2n_blob_slice
+
+include ../Makefile.common

--- a/tests/cbmc/proofs/s2n_dh_compute_shared_secret_as_server/Makefile
+++ b/tests/cbmc/proofs/s2n_dh_compute_shared_secret_as_server/Makefile
@@ -1,4 +1,3 @@
-# Copyright Amazon.com, Inc. or its affiliates. All Rights Reserved.
 #
 # Licensed under the Apache License, Version 2.0 (the "License"). You may not use
 # this file except in compliance with the License. A copy of the License is

--- a/tests/cbmc/proofs/s2n_dh_compute_shared_secret_as_server/Makefile.backup
+++ b/tests/cbmc/proofs/s2n_dh_compute_shared_secret_as_server/Makefile.backup
@@ -1,0 +1,49 @@
+# Copyright Amazon.com, Inc. or its affiliates. All Rights Reserved.
+#
+# Licensed under the Apache License, Version 2.0 (the "License"). You may not use
+# this file except in compliance with the License. A copy of the License is
+# located at
+#
+#     http://aws.amazon.com/apache2.0/
+#
+# or in the "license" file accompanying this file. This file is distributed on an
+# "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or
+# implied. See the License for the specific language governing permissions and
+# limitations under the License.
+
+# Expected runtime is 17 seconds.
+
+CHECKFLAGS +=
+
+PROOF_UID = s2n_dh_compute_shared_secret_as_server
+HARNESS_ENTRY = $(PROOF_UID)_harness
+HARNESS_FILE = $(HARNESS_ENTRY).c
+
+PROOF_SOURCES += $(PROOFDIR)/$(HARNESS_FILE)
+PROOF_SOURCES += $(OPENSSL_SOURCE)/dh_override.c
+PROOF_SOURCES += $(OPENSSL_SOURCE)/bn_override.c
+PROOF_SOURCES += $(PROOF_SOURCE)/cbmc_utils.c
+PROOF_SOURCES += $(PROOF_SOURCE)/make_common_datastructures.c
+PROOF_SOURCES += $(PROOF_STUB)/mlock.c
+PROOF_SOURCES += $(PROOF_STUB)/posix_memalign_override.c
+PROOF_SOURCES += $(PROOF_STUB)/sysconf.c
+PROOF_SOURCES += $(PROOF_STUB)/s2n_calculate_stacktrace.c
+
+PROJECT_SOURCES += $(SRCDIR)/crypto/s2n_dhe.c
+PROJECT_SOURCES += $(SRCDIR)/stuffer/s2n_stuffer.c
+PROJECT_SOURCES += $(SRCDIR)/stuffer/s2n_stuffer_network_order.c
+PROJECT_SOURCES += $(SRCDIR)/utils/s2n_blob.c
+PROJECT_SOURCES += $(SRCDIR)/utils/s2n_mem.c
+PROJECT_SOURCES += $(SRCDIR)/utils/s2n_result.c
+PROJECT_SOURCES += $(SRCDIR)/utils/s2n_safety.c
+
+UNWINDSET +=
+
+# We abstract this function because manual inspection demonstrates it is unreachable.
+REMOVE_FUNCTION_BODY += __CPROVER_file_local_s2n_mem_c_s2n_mem_cleanup_impl
+REMOVE_FUNCTION_BODY += __CPROVER_file_local_s2n_mem_c_s2n_mem_free_mlock_impl
+REMOVE_FUNCTION_BODY += s2n_blob_slice
+REMOVE_FUNCTION_BODY += s2n_blob_zero
+REMOVE_FUNCTION_BODY += s2n_free
+
+include ../Makefile.common

--- a/tests/cbmc/proofs/s2n_dh_generate_ephemeral_key/Makefile
+++ b/tests/cbmc/proofs/s2n_dh_generate_ephemeral_key/Makefile
@@ -1,4 +1,3 @@
-# Copyright Amazon.com, Inc. or its affiliates. All Rights Reserved.
 #
 # Licensed under the Apache License, Version 2.0 (the "License"). You may not use
 # this file except in compliance with the License. A copy of the License is

--- a/tests/cbmc/proofs/s2n_dh_generate_ephemeral_key/Makefile.backup
+++ b/tests/cbmc/proofs/s2n_dh_generate_ephemeral_key/Makefile.backup
@@ -1,0 +1,38 @@
+# Copyright Amazon.com, Inc. or its affiliates. All Rights Reserved.
+#
+# Licensed under the Apache License, Version 2.0 (the "License"). You may not use
+# this file except in compliance with the License. A copy of the License is
+# located at
+#
+#     http://aws.amazon.com/apache2.0/
+#
+# or in the "license" file accompanying this file. This file is distributed on an
+# "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or
+# implied. See the License for the specific language governing permissions and
+# limitations under the License.
+
+# Expected runtime is 12 seconds.
+
+CHECKFLAGS +=
+
+PROOF_UID = s2n_dh_generate_ephemeral_key
+HARNESS_ENTRY = $(PROOF_UID)_harness
+HARNESS_FILE = $(HARNESS_ENTRY).c
+
+PROOF_SOURCES += $(PROOFDIR)/$(HARNESS_FILE)
+PROOF_SOURCES += $(OPENSSL_SOURCE)/bn_override.c
+PROOF_SOURCES += $(OPENSSL_SOURCE)/dh_override.c
+PROOF_SOURCES += $(PROOF_SOURCE)/cbmc_utils.c
+PROOF_SOURCES += $(PROOF_SOURCE)/make_common_datastructures.c
+PROOF_SOURCES += $(PROOF_STUB)/sysconf.c
+PROOF_SOURCES += $(PROOF_STUB)/s2n_calculate_stacktrace.c
+
+PROJECT_SOURCES += $(SRCDIR)/crypto/s2n_dhe.c
+PROJECT_SOURCES += $(SRCDIR)/utils/s2n_mem.c
+
+UNWINDSET +=
+
+# We abstract this function because manual inspection demonstrates it is unreachable.
+REMOVE_FUNCTION_BODY += __CPROVER_file_local_s2n_mem_c_s2n_mem_cleanup_impl
+
+include ../Makefile.common

--- a/tests/cbmc/proofs/s2n_dh_p_g_Ys_to_dh_params/Makefile
+++ b/tests/cbmc/proofs/s2n_dh_p_g_Ys_to_dh_params/Makefile
@@ -1,4 +1,3 @@
-# Copyright Amazon.com, Inc. or its affiliates. All Rights Reserved.
 #
 # Licensed under the Apache License, Version 2.0 (the "License"). You may not use
 # this file except in compliance with the License. A copy of the License is

--- a/tests/cbmc/proofs/s2n_dh_p_g_Ys_to_dh_params/Makefile.backup
+++ b/tests/cbmc/proofs/s2n_dh_p_g_Ys_to_dh_params/Makefile.backup
@@ -1,0 +1,40 @@
+# Copyright Amazon.com, Inc. or its affiliates. All Rights Reserved.
+#
+# Licensed under the Apache License, Version 2.0 (the "License"). You may not use
+# this file except in compliance with the License. A copy of the License is
+# located at
+#
+#     http://aws.amazon.com/apache2.0/
+#
+# or in the "license" file accompanying this file. This file is distributed on an
+# "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or
+# implied. See the License for the specific language governing permissions and
+# limitations under the License.
+
+# Expected runtime is 7 seconds.
+
+CHECKFLAGS +=
+
+PROOF_UID = s2n_dh_p_g_Ys_to_dh_params
+HARNESS_ENTRY = $(PROOF_UID)_harness
+HARNESS_FILE = $(HARNESS_ENTRY).c
+
+PROOF_SOURCES += $(PROOFDIR)/$(HARNESS_FILE)
+PROOF_SOURCES += $(OPENSSL_SOURCE)/dh_override.c
+PROOF_SOURCES += $(OPENSSL_SOURCE)/bn_override.c
+PROOF_SOURCES += $(PROOF_SOURCE)/cbmc_utils.c
+PROOF_SOURCES += $(PROOF_SOURCE)/make_common_datastructures.c
+PROOF_SOURCES += $(PROOF_STUB)/sysconf.c
+PROOF_SOURCES += $(PROOF_STUB)/s2n_calculate_stacktrace.c
+
+PROJECT_SOURCES += $(SRCDIR)/utils/s2n_blob.c
+PROJECT_SOURCES += $(SRCDIR)/crypto/s2n_dhe.c
+PROJECT_SOURCES += $(SRCDIR)/utils/s2n_mem.c
+PROJECT_SOURCES += $(SRCDIR)/utils/s2n_result.c
+
+UNWINDSET +=
+
+# We abstract this function because manual inspection demonstrates it is unreachable.
+REMOVE_FUNCTION_BODY += __CPROVER_file_local_s2n_mem_c_s2n_mem_cleanup_impl
+
+include ../Makefile.common

--- a/tests/cbmc/proofs/s2n_dh_params_check/Makefile
+++ b/tests/cbmc/proofs/s2n_dh_params_check/Makefile
@@ -1,4 +1,3 @@
-# Copyright Amazon.com, Inc. or its affiliates. All Rights Reserved.
 #
 # Licensed under the Apache License, Version 2.0 (the "License"). You may not use
 # this file except in compliance with the License. A copy of the License is

--- a/tests/cbmc/proofs/s2n_dh_params_check/Makefile.backup
+++ b/tests/cbmc/proofs/s2n_dh_params_check/Makefile.backup
@@ -1,0 +1,37 @@
+# Copyright Amazon.com, Inc. or its affiliates. All Rights Reserved.
+#
+# Licensed under the Apache License, Version 2.0 (the "License"). You may not use
+# this file except in compliance with the License. A copy of the License is
+# located at
+#
+#     http://aws.amazon.com/apache2.0/
+#
+# or in the "license" file accompanying this file. This file is distributed on an
+# "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or
+# implied. See the License for the specific language governing permissions and
+# limitations under the License.
+
+# Expected runtime is 10 seconds.
+
+CHECKFLAGS +=
+
+PROOF_UID = s2n_dh_params_check
+HARNESS_ENTRY = $(PROOF_UID)_harness
+HARNESS_FILE = $(HARNESS_ENTRY).c
+
+PROOF_SOURCES += $(PROOFDIR)/$(HARNESS_FILE)
+PROOF_SOURCES += $(OPENSSL_SOURCE)/dh_override.c
+PROOF_SOURCES += $(PROOF_SOURCE)/cbmc_utils.c
+PROOF_SOURCES += $(PROOF_SOURCE)/make_common_datastructures.c
+PROOF_SOURCES += $(PROOF_STUB)/sysconf.c
+PROOF_SOURCES += $(PROOF_STUB)/s2n_calculate_stacktrace.c
+
+PROJECT_SOURCES += $(SRCDIR)/crypto/s2n_dhe.c
+PROJECT_SOURCES += $(SRCDIR)/utils/s2n_mem.c
+
+UNWINDSET +=
+
+# We abstract this function because manual inspection demonstrates it is unreachable.
+REMOVE_FUNCTION_BODY += __CPROVER_file_local_s2n_mem_c_s2n_mem_cleanup_impl
+
+include ../Makefile.common

--- a/tests/cbmc/proofs/s2n_dh_params_copy/Makefile
+++ b/tests/cbmc/proofs/s2n_dh_params_copy/Makefile
@@ -1,4 +1,3 @@
-# Copyright Amazon.com, Inc. or its affiliates. All Rights Reserved.
 #
 # Licensed under the Apache License, Version 2.0 (the "License"). You may not use
 # this file except in compliance with the License. A copy of the License is

--- a/tests/cbmc/proofs/s2n_dh_params_copy/Makefile.backup
+++ b/tests/cbmc/proofs/s2n_dh_params_copy/Makefile.backup
@@ -1,0 +1,38 @@
+# Copyright Amazon.com, Inc. or its affiliates. All Rights Reserved.
+#
+# Licensed under the Apache License, Version 2.0 (the "License"). You may not use
+# this file except in compliance with the License. A copy of the License is
+# located at
+#
+#     http://aws.amazon.com/apache2.0/
+#
+# or in the "license" file accompanying this file. This file is distributed on an
+# "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or
+# implied. See the License for the specific language governing permissions and
+# limitations under the License.
+
+# Expected runtime is 12 seconds.
+
+CHECKFLAGS +=
+
+PROOF_UID = s2n_dh_params_copy
+HARNESS_ENTRY = $(PROOF_UID)_harness
+HARNESS_FILE = $(HARNESS_ENTRY).c
+
+PROOF_SOURCES += $(PROOFDIR)/$(HARNESS_FILE)
+PROOF_SOURCES += $(OPENSSL_SOURCE)/bn_override.c
+PROOF_SOURCES += $(OPENSSL_SOURCE)/dh_override.c
+PROOF_SOURCES += $(PROOF_SOURCE)/cbmc_utils.c
+PROOF_SOURCES += $(PROOF_SOURCE)/make_common_datastructures.c
+PROOF_SOURCES += $(PROOF_STUB)/sysconf.c
+PROOF_SOURCES += $(PROOF_STUB)/s2n_calculate_stacktrace.c
+
+PROJECT_SOURCES += $(SRCDIR)/crypto/s2n_dhe.c
+PROJECT_SOURCES += $(SRCDIR)/utils/s2n_mem.c
+
+UNWINDSET +=
+
+# We abstract this function because manual inspection demonstrates it is unreachable.
+REMOVE_FUNCTION_BODY += __CPROVER_file_local_s2n_mem_c_s2n_mem_cleanup_impl
+
+include ../Makefile.common

--- a/tests/cbmc/proofs/s2n_dh_params_free/Makefile
+++ b/tests/cbmc/proofs/s2n_dh_params_free/Makefile
@@ -1,4 +1,3 @@
-# Copyright Amazon.com, Inc. or its affiliates. All Rights Reserved.
 #
 # Licensed under the Apache License, Version 2.0 (the "License"). You may not use
 # this file except in compliance with the License. A copy of the License is

--- a/tests/cbmc/proofs/s2n_dh_params_free/Makefile.backup
+++ b/tests/cbmc/proofs/s2n_dh_params_free/Makefile.backup
@@ -1,0 +1,38 @@
+# Copyright Amazon.com, Inc. or its affiliates. All Rights Reserved.
+#
+# Licensed under the Apache License, Version 2.0 (the "License"). You may not use
+# this file except in compliance with the License. A copy of the License is
+# located at
+#
+#     http://aws.amazon.com/apache2.0/
+#
+# or in the "license" file accompanying this file. This file is distributed on an
+# "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or
+# implied. See the License for the specific language governing permissions and
+# limitations under the License.
+
+# Expected runtime is 10 seconds.
+
+CHECKFLAGS += --memory-leak-check
+
+PROOF_UID = s2n_dh_params_free
+HARNESS_ENTRY = $(PROOF_UID)_harness
+HARNESS_FILE = $(HARNESS_ENTRY).c
+
+PROOF_SOURCES += $(PROOFDIR)/$(HARNESS_FILE)
+PROOF_SOURCES += $(OPENSSL_SOURCE)/bn_override.c
+PROOF_SOURCES += $(OPENSSL_SOURCE)/dh_override.c
+PROOF_SOURCES += $(PROOF_SOURCE)/cbmc_utils.c
+PROOF_SOURCES += $(PROOF_SOURCE)/make_common_datastructures.c
+PROOF_SOURCES += $(PROOF_STUB)/sysconf.c
+PROOF_SOURCES += $(PROOF_STUB)/s2n_calculate_stacktrace.c
+
+PROJECT_SOURCES += $(SRCDIR)/crypto/s2n_dhe.c
+PROJECT_SOURCES += $(SRCDIR)/utils/s2n_mem.c
+
+UNWINDSET +=
+
+# We abstract this function because manual inspection demonstrates it is unreachable.
+REMOVE_FUNCTION_BODY += __CPROVER_file_local_s2n_mem_c_s2n_mem_cleanup_impl
+
+include ../Makefile.common

--- a/tests/cbmc/proofs/s2n_dh_params_to_p_g_Ys/Makefile
+++ b/tests/cbmc/proofs/s2n_dh_params_to_p_g_Ys/Makefile
@@ -1,4 +1,3 @@
-# Copyright Amazon.com, Inc. or its affiliates. All Rights Reserved.
 #
 # Licensed under the Apache License, Version 2.0 (the "License"). You may not use
 # this file except in compliance with the License. A copy of the License is

--- a/tests/cbmc/proofs/s2n_dh_params_to_p_g_Ys/Makefile.backup
+++ b/tests/cbmc/proofs/s2n_dh_params_to_p_g_Ys/Makefile.backup
@@ -1,0 +1,47 @@
+# Copyright Amazon.com, Inc. or its affiliates. All Rights Reserved.
+#
+# Licensed under the Apache License, Version 2.0 (the "License"). You may not use
+# this file except in compliance with the License. A copy of the License is
+# located at
+#
+#     http://aws.amazon.com/apache2.0/
+#
+# or in the "license" file accompanying this file. This file is distributed on an
+# "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or
+# implied. See the License for the specific language governing permissions and
+# limitations under the License.
+
+# Expected runtime is 5 minutes.
+
+CHECKFLAGS +=
+
+PROOF_UID = s2n_dh_params_to_p_g_Ys
+HARNESS_ENTRY = $(PROOF_UID)_harness
+HARNESS_FILE = $(HARNESS_ENTRY).c
+
+PROOF_SOURCES += $(PROOFDIR)/$(HARNESS_FILE)
+PROOF_SOURCES += $(OPENSSL_SOURCE)/dh_override.c
+PROOF_SOURCES += $(OPENSSL_SOURCE)/bn_override.c
+PROOF_SOURCES += $(PROOF_SOURCE)/cbmc_utils.c
+PROOF_SOURCES += $(PROOF_SOURCE)/make_common_datastructures.c
+PROOF_SOURCES += $(PROOF_STUB)/mlock.c
+PROOF_SOURCES += $(PROOF_STUB)/munlock.c
+PROOF_SOURCES += $(PROOF_STUB)/sysconf.c
+PROOF_SOURCES += $(PROOF_STUB)/s2n_calculate_stacktrace.c
+
+PROJECT_SOURCES += $(SRCDIR)/crypto/s2n_dhe.c
+PROJECT_SOURCES += $(SRCDIR)/stuffer/s2n_stuffer.c
+PROJECT_SOURCES += $(SRCDIR)/stuffer/s2n_stuffer_network_order.c
+PROJECT_SOURCES += $(SRCDIR)/utils/s2n_blob.c
+PROJECT_SOURCES += $(SRCDIR)/utils/s2n_mem.c
+PROJECT_SOURCES += $(SRCDIR)/utils/s2n_safety.c
+PROJECT_SOURCES += $(SRCDIR)/utils/s2n_result.c
+
+REMOVE_FUNCTION_BODY += __CPROVER_file_local_s2n_mem_c_s2n_mem_cleanup_impl
+REMOVE_FUNCTION_BODY += s2n_free
+REMOVE_FUNCTION_BODY += s2n_realloc
+REMOVE_FUNCTION_BODY += s2n_stuffer_wipe
+
+UNWINDSET += s2n_stuffer_write_network_order.4:9
+
+include ../Makefile.common

--- a/tests/cbmc/proofs/s2n_digest_allow_md5_for_fips/Makefile
+++ b/tests/cbmc/proofs/s2n_digest_allow_md5_for_fips/Makefile
@@ -1,4 +1,3 @@
-# Copyright Amazon.com, Inc. or its affiliates. All Rights Reserved.
 #
 # Licensed under the Apache License, Version 2.0 (the "License"). You may not use
 # this file except in compliance with the License. A copy of the License is

--- a/tests/cbmc/proofs/s2n_digest_allow_md5_for_fips/Makefile.backup
+++ b/tests/cbmc/proofs/s2n_digest_allow_md5_for_fips/Makefile.backup
@@ -1,0 +1,32 @@
+# Copyright Amazon.com, Inc. or its affiliates. All Rights Reserved.
+#
+# Licensed under the Apache License, Version 2.0 (the "License"). You may not use
+# this file except in compliance with the License. A copy of the License is
+# located at
+#
+#     http://aws.amazon.com/apache2.0/
+#
+# or in the "license" file accompanying this file. This file is distributed on an
+# "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or
+# implied. See the License for the specific language governing permissions and
+# limitations under the License.
+
+# Expected runtime is less than 5 seconds.
+
+CBMCFLAGS +=
+
+PROOF_UID = s2n_digest_allow_md5_for_fips
+HARNESS_ENTRY = $(PROOF_UID)_harness
+HARNESS_FILE = $(HARNESS_ENTRY).c
+
+PROOF_SOURCES += $(PROOFDIR)/$(HARNESS_FILE)
+PROOF_SOURCES += $(PROOF_SOURCE)/make_common_datastructures.c
+PROOF_SOURCES += $(OPENSSL_SOURCE)/evp_override.c
+PROOF_SOURCES += $(PROOF_STUB)/s2n_calculate_stacktrace.c
+PROOF_SOURCES += $(PROOF_STUB)/s2n_is_in_fips_mode.c
+
+PROJECT_SOURCES += $(SRCDIR)/crypto/s2n_evp.c
+
+UNWINDSET +=
+
+include ../Makefile.common

--- a/tests/cbmc/proofs/s2n_digest_allow_md5_for_fips_boringssl_awslc/Makefile
+++ b/tests/cbmc/proofs/s2n_digest_allow_md5_for_fips_boringssl_awslc/Makefile
@@ -1,4 +1,3 @@
-# Copyright Amazon.com, Inc. or its affiliates. All Rights Reserved.
 #
 # Licensed under the Apache License, Version 2.0 (the "License"). You may not use
 # this file except in compliance with the License. A copy of the License is

--- a/tests/cbmc/proofs/s2n_digest_allow_md5_for_fips_boringssl_awslc/Makefile.backup
+++ b/tests/cbmc/proofs/s2n_digest_allow_md5_for_fips_boringssl_awslc/Makefile.backup
@@ -1,0 +1,35 @@
+# Copyright Amazon.com, Inc. or its affiliates. All Rights Reserved.
+#
+# Licensed under the Apache License, Version 2.0 (the "License"). You may not use
+# this file except in compliance with the License. A copy of the License is
+# located at
+#
+#     http://aws.amazon.com/apache2.0/
+#
+# or in the "license" file accompanying this file. This file is distributed on an
+# "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or
+# implied. See the License for the specific language governing permissions and
+# limitations under the License.
+
+# Expected runtime is less than 5 seconds.
+
+DEFINES += -DOPENSSL_IS_BORINGSSL=1
+DEFINES += -DOPENSSL_IS_AWSLC=1
+
+CBMCFLAGS +=
+
+PROOF_UID = s2n_digest_allow_md5_for_fips_boringssl_awslc
+HARNESS_ENTRY = $(PROOF_UID)_harness
+HARNESS_FILE = $(HARNESS_ENTRY).c
+
+PROOF_SOURCES += $(PROOFDIR)/$(HARNESS_FILE)
+PROOF_SOURCES += $(PROOF_SOURCE)/make_common_datastructures.c
+PROOF_SOURCES += $(OPENSSL_SOURCE)/evp_override.c
+PROOF_SOURCES += $(PROOF_STUB)/s2n_calculate_stacktrace.c
+PROOF_SOURCES += $(PROOF_STUB)/s2n_is_in_fips_mode.c
+
+PROJECT_SOURCES += $(SRCDIR)/crypto/s2n_evp.c
+
+UNWINDSET +=
+
+include ../Makefile.common

--- a/tests/cbmc/proofs/s2n_digest_is_md5_allowed_for_fips/Makefile
+++ b/tests/cbmc/proofs/s2n_digest_is_md5_allowed_for_fips/Makefile
@@ -1,4 +1,3 @@
-# Copyright Amazon.com, Inc. or its affiliates. All Rights Reserved.
 #
 # Licensed under the Apache License, Version 2.0 (the "License"). You may not use
 # this file except in compliance with the License. A copy of the License is

--- a/tests/cbmc/proofs/s2n_digest_is_md5_allowed_for_fips/Makefile.backup
+++ b/tests/cbmc/proofs/s2n_digest_is_md5_allowed_for_fips/Makefile.backup
@@ -1,0 +1,33 @@
+# Copyright Amazon.com, Inc. or its affiliates. All Rights Reserved.
+#
+# Licensed under the Apache License, Version 2.0 (the "License"). You may not use
+# this file except in compliance with the License. A copy of the License is
+# located at
+#
+#     http://aws.amazon.com/apache2.0/
+#
+# or in the "license" file accompanying this file. This file is distributed on an
+# "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or
+# implied. See the License for the specific language governing permissions and
+# limitations under the License.
+
+# Expected runtime is less than 5 seconds.
+
+CBMCFLAGS +=
+
+PROOF_UID = s2n_digest_is_md5_allowed_for_fips
+HARNESS_ENTRY = $(PROOF_UID)_harness
+HARNESS_FILE = $(HARNESS_ENTRY).c
+
+PROOF_SOURCES += $(PROOFDIR)/$(HARNESS_FILE)
+PROOF_SOURCES += $(PROOF_SOURCE)/make_common_datastructures.c
+PROOF_SOURCES += $(OPENSSL_SOURCE)/evp_override.c
+PROOF_SOURCES += $(PROOF_STUB)/s2n_calculate_stacktrace.c
+PROOF_SOURCES += $(PROOF_STUB)/s2n_is_in_fips_mode.c
+
+PROJECT_SOURCES += $(SRCDIR)/crypto/s2n_evp.c
+PROJECT_SOURCES += $(SRCDIR)/utils/s2n_result.c
+
+UNWINDSET +=
+
+include ../Makefile.common

--- a/tests/cbmc/proofs/s2n_dup/Makefile
+++ b/tests/cbmc/proofs/s2n_dup/Makefile
@@ -1,4 +1,3 @@
-# Copyright Amazon.com, Inc. or its affiliates. All Rights Reserved.
 #
 # Licensed under the Apache License, Version 2.0 (the "License"). You may not use
 # this file except in compliance with the License. A copy of the License is

--- a/tests/cbmc/proofs/s2n_dup/Makefile.backup
+++ b/tests/cbmc/proofs/s2n_dup/Makefile.backup
@@ -1,0 +1,45 @@
+# Copyright Amazon.com, Inc. or its affiliates. All Rights Reserved.
+#
+# Licensed under the Apache License, Version 2.0 (the "License"). You may not use
+# this file except in compliance with the License. A copy of the License is
+# located at
+#
+#     http://aws.amazon.com/apache2.0/
+#
+# or in the "license" file accompanying this file. This file is distributed on an
+# "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or
+# implied. See the License for the specific language governing permissions and
+# limitations under the License.
+
+# Expected runtime is 20 seconds.
+
+CHECKFLAGS +=
+
+PROOF_UID = s2n_dup
+HARNESS_ENTRY = $(PROOF_UID)_harness
+HARNESS_FILE = $(HARNESS_ENTRY).c
+
+PROOF_SOURCES += $(PROOFDIR)/$(HARNESS_FILE)
+PROOF_SOURCES += $(PROOF_SOURCE)/cbmc_utils.c
+PROOF_SOURCES += $(PROOF_SOURCE)/make_common_datastructures.c
+PROOF_SOURCES += $(PROOF_STUB)/madvise.c
+PROOF_SOURCES += $(PROOF_STUB)/mlock.c
+PROOF_SOURCES += $(PROOF_STUB)/posix_memalign_override.c
+PROOF_SOURCES += $(PROOF_STUB)/s2n_calculate_stacktrace.c
+PROOF_SOURCES += $(PROOF_STUB)/sysconf.c
+
+PROJECT_SOURCES += $(SRCDIR)/utils/s2n_blob.c
+PROJECT_SOURCES += $(SRCDIR)/utils/s2n_ensure.c
+PROJECT_SOURCES += $(SRCDIR)/utils/s2n_mem.c
+PROJECT_SOURCES += $(SRCDIR)/utils/s2n_result.c
+PROJECT_SOURCES += $(SRCDIR)/utils/s2n_safety.c
+
+# We abstract these functions because manual inspection demonstrates they are unreachable.
+REMOVE_FUNCTION_BODY += __CPROVER_file_local_s2n_mem_c_s2n_mem_cleanup_impl
+REMOVE_FUNCTION_BODY += s2n_blob_slice
+REMOVE_FUNCTION_BODY += s2n_blob_zero
+REMOVE_FUNCTION_BODY += s2n_free
+
+UNWINDSET +=
+
+include ../Makefile.common

--- a/tests/cbmc/proofs/s2n_free/Makefile
+++ b/tests/cbmc/proofs/s2n_free/Makefile
@@ -1,4 +1,3 @@
-# Copyright Amazon.com, Inc. or its affiliates. All Rights Reserved.
 #
 # Licensed under the Apache License, Version 2.0 (the "License"). You may not use
 # this file except in compliance with the License. A copy of the License is

--- a/tests/cbmc/proofs/s2n_free/Makefile.backup
+++ b/tests/cbmc/proofs/s2n_free/Makefile.backup
@@ -1,0 +1,37 @@
+# Copyright Amazon.com, Inc. or its affiliates. All Rights Reserved.
+#
+# Licensed under the Apache License, Version 2.0 (the "License"). You may not use
+# this file except in compliance with the License. A copy of the License is
+# located at
+#
+#     http://aws.amazon.com/apache2.0/
+#
+# or in the "license" file accompanying this file. This file is distributed on an
+# "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or
+# implied. See the License for the specific language governing permissions and
+# limitations under the License.
+
+CHECKFLAGS += --memory-leak-check
+
+PROOF_UID = s2n_free
+HARNESS_ENTRY = $(PROOF_UID)_harness
+HARNESS_FILE = $(HARNESS_ENTRY).c
+
+PROOF_SOURCES += $(PROOFDIR)/$(HARNESS_FILE)
+PROOF_SOURCES += $(PROOF_SOURCE)/cbmc_utils.c
+PROOF_SOURCES += $(PROOF_SOURCE)/make_common_datastructures.c
+
+PROOF_SOURCES += $(PROOF_STUB)/munlock.c
+PROOF_SOURCES += $(PROOF_STUB)/s2n_calculate_stacktrace.c
+PROOF_SOURCES += $(PROOF_STUB)/sysconf.c
+
+
+PROJECT_SOURCES += $(SRCDIR)/utils/s2n_blob.c
+PROJECT_SOURCES += $(SRCDIR)/utils/s2n_mem.c
+PROJECT_SOURCES += $(SRCDIR)/utils/s2n_result.c
+
+REMOVE_FUNCTION_BODY += __CPROVER_file_local_s2n_mem_c_s2n_mem_cleanup_impl
+
+UNWINDSET +=
+
+include ../Makefile.common

--- a/tests/cbmc/proofs/s2n_free_object/Makefile
+++ b/tests/cbmc/proofs/s2n_free_object/Makefile
@@ -1,4 +1,3 @@
-# Copyright Amazon.com, Inc. or its affiliates. All Rights Reserved.
 #
 # Licensed under the Apache License, Version 2.0 (the "License"). You may not use
 # this file except in compliance with the License. A copy of the License is

--- a/tests/cbmc/proofs/s2n_free_object/Makefile.backup
+++ b/tests/cbmc/proofs/s2n_free_object/Makefile.backup
@@ -1,0 +1,36 @@
+# Copyright Amazon.com, Inc. or its affiliates. All Rights Reserved.
+#
+# Licensed under the Apache License, Version 2.0 (the "License"). You may not use
+# this file except in compliance with the License. A copy of the License is
+# located at
+#
+#     http://aws.amazon.com/apache2.0/
+#
+# or in the "license" file accompanying this file. This file is distributed on an
+# "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or
+# implied. See the License for the specific language governing permissions and
+# limitations under the License.
+
+CHECKFLAGS += --memory-leak-check
+
+PROOF_UID = s2n_free_object
+HARNESS_ENTRY = $(PROOF_UID)_harness
+HARNESS_FILE = $(HARNESS_ENTRY).c
+
+PROOF_SOURCES += $(PROOFDIR)/$(HARNESS_FILE)
+PROOF_SOURCES += $(PROOF_SOURCE)/cbmc_utils.c
+PROOF_SOURCES += $(PROOF_SOURCE)/make_common_datastructures.c
+
+PROOF_SOURCES += $(PROOF_STUB)/munlock.c
+PROOF_SOURCES += $(PROOF_STUB)/s2n_calculate_stacktrace.c
+PROOF_SOURCES += $(PROOF_STUB)/sysconf.c
+
+PROJECT_SOURCES += $(SRCDIR)/utils/s2n_blob.c
+PROJECT_SOURCES += $(SRCDIR)/utils/s2n_mem.c
+PROJECT_SOURCES += $(SRCDIR)/utils/s2n_result.c
+
+REMOVE_FUNCTION_BODY += __CPROVER_file_local_s2n_mem_c_s2n_mem_cleanup_impl
+
+UNWINDSET +=
+
+include ../Makefile.common

--- a/tests/cbmc/proofs/s2n_hash_allow_md5_for_fips/Makefile
+++ b/tests/cbmc/proofs/s2n_hash_allow_md5_for_fips/Makefile
@@ -1,4 +1,3 @@
-# Copyright Amazon.com, Inc. or its affiliates. All Rights Reserved.
 #
 # Licensed under the Apache License, Version 2.0 (the "License"). You may not use
 # this file except in compliance with the License. A copy of the License is

--- a/tests/cbmc/proofs/s2n_hash_allow_md5_for_fips/Makefile.backup
+++ b/tests/cbmc/proofs/s2n_hash_allow_md5_for_fips/Makefile.backup
@@ -1,0 +1,43 @@
+# Copyright Amazon.com, Inc. or its affiliates. All Rights Reserved.
+#
+# Licensed under the Apache License, Version 2.0 (the "License"). You may not use
+# this file except in compliance with the License. A copy of the License is
+# located at
+#
+#     http://aws.amazon.com/apache2.0/
+#
+# or in the "license" file accompanying this file. This file is distributed on an
+# "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or
+# implied. See the License for the specific language governing permissions and
+# limitations under the License.
+
+# Expected runtime is less than 20 seconds.
+
+CBMCFLAGS +=
+
+PROOF_UID = s2n_hash_allow_md5_for_fips
+HARNESS_ENTRY = $(PROOF_UID)_harness
+HARNESS_FILE = $(HARNESS_ENTRY).c
+
+PROOF_SOURCES += $(PROOFDIR)/$(HARNESS_FILE)
+PROOF_SOURCES += $(PROOF_SOURCE)/make_common_datastructures.c
+PROOF_SOURCES += $(OPENSSL_SOURCE)/evp_override.c
+PROOF_SOURCES += $(PROOF_STUB)/s2n_is_in_fips_mode.c
+
+PROJECT_SOURCES += $(SRCDIR)/crypto/s2n_hash.c
+PROJECT_SOURCES += $(SRCDIR)/crypto/s2n_evp.c
+PROJECT_SOURCES += $(SRCDIR)/utils/s2n_result.c
+
+# We abstract these functions because manual inspection demonstrates they are unreachable.
+REMOVE_FUNCTION_BODY += __CPROVER_file_local_s2n_hash_c_s2n_low_level_hash_new
+REMOVE_FUNCTION_BODY += __CPROVER_file_local_s2n_hash_c_s2n_low_level_hash_init
+REMOVE_FUNCTION_BODY += __CPROVER_file_local_s2n_hash_c_s2n_low_level_hash_reset
+REMOVE_FUNCTION_BODY += __CPROVER_file_local_s2n_hash_c_s2n_evp_hash_new
+REMOVE_FUNCTION_BODY += __CPROVER_file_local_s2n_hash_c_s2n_evp_hash_init
+REMOVE_FUNCTION_BODY += __CPROVER_file_local_s2n_hash_c_s2n_evp_hash_reset
+REMOVE_FUNCTION_BODY += __CPROVER_file_local_s2n_hash_c_s2n_evp_hash_free
+REMOVE_FUNCTION_BODY += __CPROVER_file_local_s2n_hash_c_s2n_low_level_hash_free
+
+UNWINDSET +=
+
+include ../Makefile.common

--- a/tests/cbmc/proofs/s2n_hash_block_size/Makefile
+++ b/tests/cbmc/proofs/s2n_hash_block_size/Makefile
@@ -1,4 +1,3 @@
-# Copyright Amazon.com, Inc. or its affiliates. All Rights Reserved.
 #
 # Licensed under the Apache License, Version 2.0 (the "License"). You may not use
 # this file except in compliance with the License. A copy of the License is

--- a/tests/cbmc/proofs/s2n_hash_block_size/Makefile.backup
+++ b/tests/cbmc/proofs/s2n_hash_block_size/Makefile.backup
@@ -1,0 +1,29 @@
+# Copyright Amazon.com, Inc. or its affiliates. All Rights Reserved.
+#
+# Licensed under the Apache License, Version 2.0 (the "License"). You may not use
+# this file except in compliance with the License. A copy of the License is
+# located at
+#
+#     http://aws.amazon.com/apache2.0/
+#
+# or in the "license" file accompanying this file. This file is distributed on an
+# "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or
+# implied. See the License for the specific language governing permissions and
+# limitations under the License.
+
+# Expected runtime is less than 5 seconds.
+
+CBMCFLAGS +=
+
+PROOF_UID = s2n_hash_block_size
+HARNESS_ENTRY = $(PROOF_UID)_harness
+HARNESS_FILE = $(HARNESS_ENTRY).c
+
+PROOF_SOURCES += $(PROOFDIR)/$(HARNESS_FILE)
+PROOF_SOURCES += $(PROOF_STUB)/s2n_calculate_stacktrace.c
+
+PROJECT_SOURCES += $(SRCDIR)/crypto/s2n_hash.c
+
+UNWINDSET +=
+
+include ../Makefile.common

--- a/tests/cbmc/proofs/s2n_hash_const_time_get_currently_in_hash_block/Makefile
+++ b/tests/cbmc/proofs/s2n_hash_const_time_get_currently_in_hash_block/Makefile
@@ -1,4 +1,3 @@
-# Copyright Amazon.com, Inc. or its affiliates. All Rights Reserved.
 #
 # Licensed under the Apache License, Version 2.0 (the "License"). You may not use
 # this file except in compliance with the License. A copy of the License is

--- a/tests/cbmc/proofs/s2n_hash_const_time_get_currently_in_hash_block/Makefile.backup
+++ b/tests/cbmc/proofs/s2n_hash_const_time_get_currently_in_hash_block/Makefile.backup
@@ -1,0 +1,32 @@
+# Copyright Amazon.com, Inc. or its affiliates. All Rights Reserved.
+#
+# Licensed under the Apache License, Version 2.0 (the "License"). You may not use
+# this file except in compliance with the License. A copy of the License is
+# located at
+#
+#     http://aws.amazon.com/apache2.0/
+#
+# or in the "license" file accompanying this file. This file is distributed on an
+# "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or
+# implied. See the License for the specific language governing permissions and
+# limitations under the License.
+
+# Expected runtime is less than 30 seconds.
+
+CBMCFLAGS +=
+
+PROOF_UID = s2n_hash_const_time_get_currently_in_hash_block
+HARNESS_ENTRY = $(PROOF_UID)_harness
+HARNESS_FILE = $(HARNESS_ENTRY).c
+
+PROOF_SOURCES += $(PROOFDIR)/$(HARNESS_FILE)
+PROOF_SOURCES += $(PROOF_SOURCE)/make_common_datastructures.c
+PROOF_SOURCES += $(PROOF_STUB)/s2n_calculate_stacktrace.c
+PROOF_SOURCES += $(PROOF_STUB)/s2n_is_in_fips_mode.c
+
+PROJECT_SOURCES += $(SRCDIR)/crypto/s2n_hash.c
+PROJECT_SOURCES += $(SRCDIR)/utils/s2n_result.c
+
+UNWINDSET +=
+
+include ../Makefile.common

--- a/tests/cbmc/proofs/s2n_hash_copy/Makefile
+++ b/tests/cbmc/proofs/s2n_hash_copy/Makefile
@@ -1,4 +1,3 @@
-# Copyright Amazon.com, Inc. or its affiliates. All Rights Reserved.
 #
 # Licensed under the Apache License, Version 2.0 (the "License"). You may not use
 # this file except in compliance with the License. A copy of the License is

--- a/tests/cbmc/proofs/s2n_hash_copy/Makefile.backup
+++ b/tests/cbmc/proofs/s2n_hash_copy/Makefile.backup
@@ -1,0 +1,48 @@
+# Copyright Amazon.com, Inc. or its affiliates. All Rights Reserved.
+#
+# Licensed under the Apache License, Version 2.0 (the "License"). You may not use
+# this file except in compliance with the License. A copy of the License is
+# located at
+#
+#     http://aws.amazon.com/apache2.0/
+#
+# or in the "license" file accompanying this file. This file is distributed on an
+# "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or
+# implied. See the License for the specific language governing permissions and
+# limitations under the License.
+
+# Expected runtime is less than 2 minutes.
+
+CBMCFLAGS +=
+
+PROOF_UID = s2n_hash_copy
+HARNESS_ENTRY = $(PROOF_UID)_harness
+HARNESS_FILE = $(HARNESS_ENTRY).c
+
+PROOF_SOURCES += $(PROOFDIR)/$(HARNESS_FILE)
+PROOF_SOURCES += $(OPENSSL_SOURCE)/bn_override.c
+PROOF_SOURCES += $(OPENSSL_SOURCE)/ec_override.c
+PROOF_SOURCES += $(OPENSSL_SOURCE)/evp_override.c
+PROOF_SOURCES += $(PROOF_SOURCE)/make_common_datastructures.c
+PROOF_SOURCES += $(PROOF_STUB)/s2n_calculate_stacktrace.c
+PROOF_SOURCES += $(PROOF_STUB)/s2n_is_in_fips_mode.c
+
+PROJECT_SOURCES += $(SRCDIR)/crypto/s2n_hash.c
+PROJECT_SOURCES += $(SRCDIR)/crypto/s2n_evp.c
+PROJECT_SOURCES += $(SRCDIR)/utils/s2n_ensure.c
+PROJECT_SOURCES += $(SRCDIR)/utils/s2n_result.c
+PROJECT_SOURCES += $(SRCDIR)/utils/s2n_safety.c
+
+# We abstract these functions because manual inspection demonstrates they are unreachable.
+REMOVE_FUNCTION_BODY += __CPROVER_file_local_s2n_hash_c_s2n_evp_hash_free
+REMOVE_FUNCTION_BODY += __CPROVER_file_local_s2n_hash_c_s2n_evp_hash_init
+REMOVE_FUNCTION_BODY += __CPROVER_file_local_s2n_hash_c_s2n_evp_hash_new
+REMOVE_FUNCTION_BODY += __CPROVER_file_local_s2n_hash_c_s2n_evp_hash_reset
+REMOVE_FUNCTION_BODY += __CPROVER_file_local_s2n_hash_c_s2n_low_level_hash_free
+REMOVE_FUNCTION_BODY += __CPROVER_file_local_s2n_hash_c_s2n_low_level_hash_init
+REMOVE_FUNCTION_BODY += __CPROVER_file_local_s2n_hash_c_s2n_low_level_hash_new
+REMOVE_FUNCTION_BODY += __CPROVER_file_local_s2n_hash_c_s2n_low_level_hash_reset
+
+UNWINDSET +=
+
+include ../Makefile.common

--- a/tests/cbmc/proofs/s2n_hash_digest/Makefile
+++ b/tests/cbmc/proofs/s2n_hash_digest/Makefile
@@ -1,4 +1,3 @@
-# Copyright Amazon.com, Inc. or its affiliates. All Rights Reserved.
 #
 # Licensed under the Apache License, Version 2.0 (the "License"). You may not use
 # this file except in compliance with the License. A copy of the License is

--- a/tests/cbmc/proofs/s2n_hash_digest/Makefile.backup
+++ b/tests/cbmc/proofs/s2n_hash_digest/Makefile.backup
@@ -1,0 +1,43 @@
+# Copyright Amazon.com, Inc. or its affiliates. All Rights Reserved.
+#
+# Licensed under the Apache License, Version 2.0 (the "License"). You may not use
+# this file except in compliance with the License. A copy of the License is
+# located at
+#
+#     http://aws.amazon.com/apache2.0/
+#
+# or in the "license" file accompanying this file. This file is distributed on an
+# "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or
+# implied. See the License for the specific language governing permissions and
+# limitations under the License.
+
+# Expected runtime is less than 2 minutes.
+
+CBMCFLAGS +=
+
+PROOF_UID = s2n_hash_digest
+HARNESS_ENTRY = $(PROOF_UID)_harness
+HARNESS_FILE = $(HARNESS_ENTRY).c
+
+PROOF_SOURCES += $(PROOFDIR)/$(HARNESS_FILE)
+PROOF_SOURCES += $(OPENSSL_SOURCE)/bn_override.c
+PROOF_SOURCES += $(OPENSSL_SOURCE)/ec_override.c
+PROOF_SOURCES += $(OPENSSL_SOURCE)/evp_override.c
+PROOF_SOURCES += $(OPENSSL_SOURCE)/md5_override.c
+PROOF_SOURCES += $(OPENSSL_SOURCE)/sha_override.c
+PROOF_SOURCES += $(PROOF_SOURCE)/make_common_datastructures.c
+PROOF_SOURCES += $(PROOF_STUB)/s2n_calculate_stacktrace.c
+PROOF_SOURCES += $(PROOF_STUB)/s2n_is_in_fips_mode.c
+
+PROJECT_SOURCES += $(SRCDIR)/crypto/s2n_hash.c
+PROJECT_SOURCES += $(SRCDIR)/crypto/s2n_evp.c
+PROJECT_SOURCES += $(SRCDIR)/utils/s2n_result.c
+PROJECT_SOURCES += $(SRCDIR)/utils/s2n_safety.c
+
+# We abstract these functions because manual inspection demonstrates they are unreachable.
+REMOVE_FUNCTION_BODY += __CPROVER_file_local_s2n_hash_c_s2n_evp_hash_update
+REMOVE_FUNCTION_BODY += __CPROVER_file_local_s2n_hash_c_s2n_low_level_hash_update
+
+UNWINDSET +=
+
+include ../Makefile.common

--- a/tests/cbmc/proofs/s2n_hash_digest_size/Makefile
+++ b/tests/cbmc/proofs/s2n_hash_digest_size/Makefile
@@ -1,4 +1,3 @@
-# Copyright Amazon.com, Inc. or its affiliates. All Rights Reserved.
 #
 # Licensed under the Apache License, Version 2.0 (the "License"). You may not use
 # this file except in compliance with the License. A copy of the License is

--- a/tests/cbmc/proofs/s2n_hash_digest_size/Makefile.backup
+++ b/tests/cbmc/proofs/s2n_hash_digest_size/Makefile.backup
@@ -1,0 +1,29 @@
+# Copyright Amazon.com, Inc. or its affiliates. All Rights Reserved.
+#
+# Licensed under the Apache License, Version 2.0 (the "License"). You may not use
+# this file except in compliance with the License. A copy of the License is
+# located at
+#
+#     http://aws.amazon.com/apache2.0/
+#
+# or in the "license" file accompanying this file. This file is distributed on an
+# "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or
+# implied. See the License for the specific language governing permissions and
+# limitations under the License.
+
+# Expected runtime is less than 5 seconds.
+
+CBMCFLAGS +=
+
+PROOF_UID = s2n_hash_digest_size
+HARNESS_ENTRY = $(PROOF_UID)_harness
+HARNESS_FILE = $(HARNESS_ENTRY).c
+
+PROOF_SOURCES += $(PROOFDIR)/$(HARNESS_FILE)
+PROOF_SOURCES += $(PROOF_STUB)/s2n_calculate_stacktrace.c
+
+PROJECT_SOURCES += $(SRCDIR)/crypto/s2n_hash.c
+
+UNWINDSET +=
+
+include ../Makefile.common

--- a/tests/cbmc/proofs/s2n_hash_free/Makefile
+++ b/tests/cbmc/proofs/s2n_hash_free/Makefile
@@ -1,4 +1,3 @@
-# Copyright Amazon.com, Inc. or its affiliates. All Rights Reserved.
 #
 # Licensed under the Apache License, Version 2.0 (the "License"). You may not use
 # this file except in compliance with the License. A copy of the License is

--- a/tests/cbmc/proofs/s2n_hash_free/Makefile.backup
+++ b/tests/cbmc/proofs/s2n_hash_free/Makefile.backup
@@ -1,0 +1,45 @@
+# Copyright Amazon.com, Inc. or its affiliates. All Rights Reserved.
+#
+# Licensed under the Apache License, Version 2.0 (the "License"). You may not use
+# this file except in compliance with the License. A copy of the License is
+# located at
+#
+#     http://aws.amazon.com/apache2.0/
+#
+# or in the "license" file accompanying this file. This file is distributed on an
+# "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or
+# implied. See the License for the specific language governing permissions and
+# limitations under the License.
+
+# Expected runtime is less than a minute.
+
+CBMCFLAGS += --memory-leak-check
+
+PROOF_UID = s2n_hash_free
+HARNESS_ENTRY = $(PROOF_UID)_harness
+HARNESS_FILE = $(HARNESS_ENTRY).c
+
+PROOF_SOURCES += $(OPENSSL_SOURCE)/bn_override.c
+PROOF_SOURCES += $(OPENSSL_SOURCE)/ec_override.c
+PROOF_SOURCES += $(OPENSSL_SOURCE)/evp_override.c
+PROOF_SOURCES += $(PROOF_SOURCE)/cbmc_utils.c
+PROOF_SOURCES += $(PROOF_SOURCE)/make_common_datastructures.c
+PROOF_SOURCES += $(PROOF_STUB)/s2n_is_in_fips_mode.c
+PROOF_SOURCES += $(PROOFDIR)/$(HARNESS_FILE)
+
+PROJECT_SOURCES += $(SRCDIR)/crypto/s2n_hash.c
+PROJECT_SOURCES += $(SRCDIR)/utils/s2n_result.c
+
+# We abstract these functions because manual inspection demonstrates they are unreachable.
+REMOVE_FUNCTION_BODY += __CPROVER_file_local_s2n_hash_c_s2n_evp_hash_init
+REMOVE_FUNCTION_BODY += __CPROVER_file_local_s2n_hash_c_s2n_evp_hash_new
+REMOVE_FUNCTION_BODY += __CPROVER_file_local_s2n_hash_c_s2n_evp_hash_reset
+REMOVE_FUNCTION_BODY += __CPROVER_file_local_s2n_hash_c_s2n_low_level_hash_init
+REMOVE_FUNCTION_BODY += __CPROVER_file_local_s2n_hash_c_s2n_low_level_hash_new
+REMOVE_FUNCTION_BODY += __CPROVER_file_local_s2n_hash_c_s2n_low_level_hash_reset
+REMOVE_FUNCTION_BODY += __CPROVER_file_local_s2n_hash_c_s2n_hash_allow_md5_for_fips
+REMOVE_FUNCTION_BODY += __CPROVER_file_local_s2n_hash_c_s2n_evp_hash_allow_md5_for_fips
+
+UNWINDSET +=
+
+include ../Makefile.common

--- a/tests/cbmc/proofs/s2n_hash_get_currently_in_hash_total/Makefile
+++ b/tests/cbmc/proofs/s2n_hash_get_currently_in_hash_total/Makefile
@@ -1,4 +1,3 @@
-# Copyright Amazon.com, Inc. or its affiliates. All Rights Reserved.
 #
 # Licensed under the Apache License, Version 2.0 (the "License"). You may not use
 # this file except in compliance with the License. A copy of the License is

--- a/tests/cbmc/proofs/s2n_hash_get_currently_in_hash_total/Makefile.backup
+++ b/tests/cbmc/proofs/s2n_hash_get_currently_in_hash_total/Makefile.backup
@@ -1,0 +1,32 @@
+# Copyright Amazon.com, Inc. or its affiliates. All Rights Reserved.
+#
+# Licensed under the Apache License, Version 2.0 (the "License"). You may not use
+# this file except in compliance with the License. A copy of the License is
+# located at
+#
+#     http://aws.amazon.com/apache2.0/
+#
+# or in the "license" file accompanying this file. This file is distributed on an
+# "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or
+# implied. See the License for the specific language governing permissions and
+# limitations under the License.
+
+# Expected runtime is less than 20 seconds.
+
+CBMCFLAGS +=
+
+PROOF_UID = s2n_hash_get_currently_in_hash_total
+HARNESS_ENTRY = $(PROOF_UID)_harness
+HARNESS_FILE = $(HARNESS_ENTRY).c
+
+PROOF_SOURCES += $(PROOFDIR)/$(HARNESS_FILE)
+PROOF_SOURCES += $(PROOF_SOURCE)/make_common_datastructures.c
+PROOF_SOURCES += $(PROOF_STUB)/s2n_calculate_stacktrace.c
+PROOF_SOURCES += $(PROOF_STUB)/s2n_is_in_fips_mode.c
+
+PROJECT_SOURCES += $(SRCDIR)/crypto/s2n_hash.c
+PROJECT_SOURCES += $(SRCDIR)/utils/s2n_result.c
+
+UNWINDSET +=
+
+include ../Makefile.common

--- a/tests/cbmc/proofs/s2n_hash_hmac_alg/Makefile
+++ b/tests/cbmc/proofs/s2n_hash_hmac_alg/Makefile
@@ -1,4 +1,3 @@
-# Copyright Amazon.com, Inc. or its affiliates. All Rights Reserved.
 #
 # Licensed under the Apache License, Version 2.0 (the "License"). You may not use
 # this file except in compliance with the License. A copy of the License is

--- a/tests/cbmc/proofs/s2n_hash_hmac_alg/Makefile.backup
+++ b/tests/cbmc/proofs/s2n_hash_hmac_alg/Makefile.backup
@@ -1,0 +1,29 @@
+# Copyright Amazon.com, Inc. or its affiliates. All Rights Reserved.
+#
+# Licensed under the Apache License, Version 2.0 (the "License"). You may not use
+# this file except in compliance with the License. A copy of the License is
+# located at
+#
+#     http://aws.amazon.com/apache2.0/
+#
+# or in the "license" file accompanying this file. This file is distributed on an
+# "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or
+# implied. See the License for the specific language governing permissions and
+# limitations under the License.
+
+# Expected runtime is less than 5 seconds.
+
+CBMCFLAGS +=
+
+PROOF_UID = s2n_hash_hmac_alg
+HARNESS_ENTRY = $(PROOF_UID)_harness
+HARNESS_FILE = $(HARNESS_ENTRY).c
+
+PROOF_SOURCES += $(PROOFDIR)/$(HARNESS_FILE)
+PROOF_SOURCES += $(PROOF_STUB)/s2n_calculate_stacktrace.c
+
+PROJECT_SOURCES += $(SRCDIR)/crypto/s2n_hmac.c
+
+UNWINDSET +=
+
+include ../Makefile.common

--- a/tests/cbmc/proofs/s2n_hash_init/Makefile
+++ b/tests/cbmc/proofs/s2n_hash_init/Makefile
@@ -1,4 +1,3 @@
-# Copyright Amazon.com, Inc. or its affiliates. All Rights Reserved.
 #
 # Licensed under the Apache License, Version 2.0 (the "License"). You may not use
 # this file except in compliance with the License. A copy of the License is

--- a/tests/cbmc/proofs/s2n_hash_init/Makefile.backup
+++ b/tests/cbmc/proofs/s2n_hash_init/Makefile.backup
@@ -1,0 +1,47 @@
+# Copyright Amazon.com, Inc. or its affiliates. All Rights Reserved.
+#
+# Licensed under the Apache License, Version 2.0 (the "License"). You may not use
+# this file except in compliance with the License. A copy of the License is
+# located at
+#
+#     http://aws.amazon.com/apache2.0/
+#
+# or in the "license" file accompanying this file. This file is distributed on an
+# "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or
+# implied. See the License for the specific language governing permissions and
+# limitations under the License.
+
+# Expected runtime is less than 5 seconds.
+
+CBMCFLAGS +=
+
+PROOF_UID = s2n_hash_init
+HARNESS_ENTRY = $(PROOF_UID)_harness
+HARNESS_FILE = $(HARNESS_ENTRY).c
+
+PROOF_SOURCES += $(OPENSSL_SOURCE)/evp_override.c
+PROOF_SOURCES += $(OPENSSL_SOURCE)/md5_override.c
+PROOF_SOURCES += $(OPENSSL_SOURCE)/sha_override.c
+PROOF_SOURCES += $(PROOF_SOURCE)/make_common_datastructures.c
+PROOF_SOURCES += $(PROOF_STUB)/s2n_calculate_stacktrace.c
+PROOF_SOURCES += $(PROOF_STUB)/s2n_is_in_fips_mode.c
+PROOF_SOURCES += $(PROOFDIR)/$(HARNESS_FILE)
+
+PROJECT_SOURCES += $(SRCDIR)/crypto/s2n_hash.c
+PROJECT_SOURCES += $(SRCDIR)/crypto/s2n_evp.c
+PROJECT_SOURCES += $(SRCDIR)/utils/s2n_result.c
+
+# We abstract these functions because manual inspection demonstrates they are unreachable.
+REMOVE_FUNCTION_BODY += __CPROVER_file_local_s2n_hash_c_s2n_low_level_hash_copy
+REMOVE_FUNCTION_BODY += __CPROVER_file_local_s2n_hash_c_s2n_low_level_hash_new
+REMOVE_FUNCTION_BODY += __CPROVER_file_local_s2n_hash_c_s2n_low_level_hash_reset
+REMOVE_FUNCTION_BODY += __CPROVER_file_local_s2n_hash_c_s2n_low_level_hash_free
+REMOVE_FUNCTION_BODY += __CPROVER_file_local_s2n_hash_c_s2n_evp_hash_allow_md5_for_fips
+REMOVE_FUNCTION_BODY += __CPROVER_file_local_s2n_hash_c_s2n_evp_hash_copy
+REMOVE_FUNCTION_BODY += __CPROVER_file_local_s2n_hash_c_s2n_evp_hash_free
+REMOVE_FUNCTION_BODY += __CPROVER_file_local_s2n_hash_c_s2n_evp_hash_new
+REMOVE_FUNCTION_BODY += __CPROVER_file_local_s2n_hash_c_s2n_evp_hash_reset
+
+UNWINDSET +=
+
+include ../Makefile.common

--- a/tests/cbmc/proofs/s2n_hash_is_available/Makefile
+++ b/tests/cbmc/proofs/s2n_hash_is_available/Makefile
@@ -1,4 +1,3 @@
-# Copyright Amazon.com, Inc. or its affiliates. All Rights Reserved.
 #
 # Licensed under the Apache License, Version 2.0 (the "License"). You may not use
 # this file except in compliance with the License. A copy of the License is

--- a/tests/cbmc/proofs/s2n_hash_is_available/Makefile.backup
+++ b/tests/cbmc/proofs/s2n_hash_is_available/Makefile.backup
@@ -1,0 +1,30 @@
+# Copyright Amazon.com, Inc. or its affiliates. All Rights Reserved.
+#
+# Licensed under the Apache License, Version 2.0 (the "License"). You may not use
+# this file except in compliance with the License. A copy of the License is
+# located at
+#
+#     http://aws.amazon.com/apache2.0/
+#
+# or in the "license" file accompanying this file. This file is distributed on an
+# "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or
+# implied. See the License for the specific language governing permissions and
+# limitations under the License.
+
+# Expected runtime is less than 5 seconds.
+
+CBMCFLAGS +=
+
+PROOF_UID = s2n_hash_is_available
+HARNESS_ENTRY = $(PROOF_UID)_harness
+HARNESS_FILE = $(HARNESS_ENTRY).c
+
+PROOF_SOURCES += $(PROOFDIR)/$(HARNESS_FILE)
+PROOF_SOURCES += $(PROOF_STUB)/s2n_calculate_stacktrace.c
+PROOF_SOURCES += $(PROOF_STUB)/s2n_is_in_fips_mode.c
+
+PROJECT_SOURCES += $(SRCDIR)/crypto/s2n_hash.c
+
+UNWINDSET +=
+
+include ../Makefile.common

--- a/tests/cbmc/proofs/s2n_hash_is_ready_for_input/Makefile
+++ b/tests/cbmc/proofs/s2n_hash_is_ready_for_input/Makefile
@@ -1,4 +1,3 @@
-# Copyright Amazon.com, Inc. or its affiliates. All Rights Reserved.
 #
 # Licensed under the Apache License, Version 2.0 (the "License"). You may not use
 # this file except in compliance with the License. A copy of the License is

--- a/tests/cbmc/proofs/s2n_hash_is_ready_for_input/Makefile.backup
+++ b/tests/cbmc/proofs/s2n_hash_is_ready_for_input/Makefile.backup
@@ -1,0 +1,30 @@
+# Copyright Amazon.com, Inc. or its affiliates. All Rights Reserved.
+#
+# Licensed under the Apache License, Version 2.0 (the "License"). You may not use
+# this file except in compliance with the License. A copy of the License is
+# located at
+#
+#     http://aws.amazon.com/apache2.0/
+#
+# or in the "license" file accompanying this file. This file is distributed on an
+# "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or
+# implied. See the License for the specific language governing permissions and
+# limitations under the License.
+
+# Expected runtime is less than 20 seconds.
+
+CBMCFLAGS +=
+
+PROOF_UID = s2n_hash_is_ready_for_input
+HARNESS_ENTRY = $(PROOF_UID)_harness
+HARNESS_FILE = $(HARNESS_ENTRY).c
+
+PROOF_SOURCES += $(PROOFDIR)/$(HARNESS_FILE)
+PROOF_SOURCES += $(PROOF_SOURCE)/make_common_datastructures.c
+
+PROJECT_SOURCES += $(SRCDIR)/crypto/s2n_hash.c
+PROJECT_SOURCES += $(SRCDIR)/utils/s2n_result.c
+
+UNWINDSET +=
+
+include ../Makefile.common

--- a/tests/cbmc/proofs/s2n_hash_new/Makefile
+++ b/tests/cbmc/proofs/s2n_hash_new/Makefile
@@ -1,4 +1,3 @@
-# Copyright Amazon.com, Inc. or its affiliates. All Rights Reserved.
 #
 # Licensed under the Apache License, Version 2.0 (the "License"). You may not use
 # this file except in compliance with the License. A copy of the License is

--- a/tests/cbmc/proofs/s2n_hash_new/Makefile.backup
+++ b/tests/cbmc/proofs/s2n_hash_new/Makefile.backup
@@ -1,0 +1,42 @@
+# Copyright Amazon.com, Inc. or its affiliates. All Rights Reserved.
+#
+# Licensed under the Apache License, Version 2.0 (the "License"). You may not use
+# this file except in compliance with the License. A copy of the License is
+# located at
+#
+#     http://aws.amazon.com/apache2.0/
+#
+# or in the "license" file accompanying this file. This file is distributed on an
+# "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or
+# implied. See the License for the specific language governing permissions and
+# limitations under the License.
+
+# Expected runtime is less than 5 seconds.
+
+CBMCFLAGS +=
+
+PROOF_UID = s2n_hash_new
+HARNESS_ENTRY = $(PROOF_UID)_harness
+HARNESS_FILE = $(HARNESS_ENTRY).c
+
+PROOF_SOURCES += $(PROOFDIR)/$(HARNESS_FILE)
+PROOF_SOURCES += $(PROOF_SOURCE)/make_common_datastructures.c
+PROOF_SOURCES += $(OPENSSL_SOURCE)/evp_override.c
+PROOF_SOURCES += $(PROOF_STUB)/s2n_is_in_fips_mode.c
+
+PROJECT_SOURCES += $(SRCDIR)/crypto/s2n_hash.c
+PROJECT_SOURCES += $(SRCDIR)/crypto/s2n_evp.c
+PROJECT_SOURCES += $(SRCDIR)/utils/s2n_result.c
+
+# We abstract these functions because manual inspection demonstrates they are unreachable.
+REMOVE_FUNCTION_BODY += __CPROVER_file_local_s2n_hash_c_s2n_low_level_hash_init
+REMOVE_FUNCTION_BODY += __CPROVER_file_local_s2n_hash_c_s2n_low_level_hash_reset
+REMOVE_FUNCTION_BODY += __CPROVER_file_local_s2n_hash_c_s2n_low_level_hash_free
+REMOVE_FUNCTION_BODY += __CPROVER_file_local_s2n_hash_c_s2n_evp_hash_allow_md5_for_fips
+REMOVE_FUNCTION_BODY += __CPROVER_file_local_s2n_hash_c_s2n_evp_hash_init
+REMOVE_FUNCTION_BODY += __CPROVER_file_local_s2n_hash_c_s2n_evp_hash_reset
+REMOVE_FUNCTION_BODY += __CPROVER_file_local_s2n_hash_c_s2n_evp_hash_free
+
+UNWINDSET +=
+
+include ../Makefile.common

--- a/tests/cbmc/proofs/s2n_hash_reset/Makefile
+++ b/tests/cbmc/proofs/s2n_hash_reset/Makefile
@@ -1,4 +1,3 @@
-# Copyright Amazon.com, Inc. or its affiliates. All Rights Reserved.
 #
 # Licensed under the Apache License, Version 2.0 (the "License"). You may not use
 # this file except in compliance with the License. A copy of the License is

--- a/tests/cbmc/proofs/s2n_hash_reset/Makefile.backup
+++ b/tests/cbmc/proofs/s2n_hash_reset/Makefile.backup
@@ -1,0 +1,45 @@
+# Copyright Amazon.com, Inc. or its affiliates. All Rights Reserved.
+#
+# Licensed under the Apache License, Version 2.0 (the "License"). You may not use
+# this file except in compliance with the License. A copy of the License is
+# located at
+#
+#     http://aws.amazon.com/apache2.0/
+#
+# or in the "license" file accompanying this file. This file is distributed on an
+# "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or
+# implied. See the License for the specific language governing permissions and
+# limitations under the License.
+
+# Expected runtime is less than 2 minutes.
+
+CBMCFLAGS +=
+
+PROOF_UID = s2n_hash_reset
+HARNESS_ENTRY = $(PROOF_UID)_harness
+HARNESS_FILE = $(HARNESS_ENTRY).c
+
+PROOF_SOURCES += $(PROOFDIR)/$(HARNESS_FILE)
+PROOF_SOURCES += $(OPENSSL_SOURCE)/bn_override.c
+PROOF_SOURCES += $(OPENSSL_SOURCE)/ec_override.c
+PROOF_SOURCES += $(OPENSSL_SOURCE)/evp_override.c
+PROOF_SOURCES += $(OPENSSL_SOURCE)/md5_override.c
+PROOF_SOURCES += $(OPENSSL_SOURCE)/sha_override.c
+PROOF_SOURCES += $(PROOF_SOURCE)/make_common_datastructures.c
+PROOF_SOURCES += $(PROOF_STUB)/s2n_calculate_stacktrace.c
+PROOF_SOURCES += $(PROOF_STUB)/s2n_is_in_fips_mode.c
+
+PROJECT_SOURCES += $(SRCDIR)/crypto/s2n_hash.c
+PROJECT_SOURCES += $(SRCDIR)/crypto/s2n_evp.c
+PROJECT_SOURCES += $(SRCDIR)/utils/s2n_result.c
+PROJECT_SOURCES += $(SRCDIR)/utils/s2n_safety.c
+
+# We abstract these functions because manual inspection demonstrates they are unreachable.
+REMOVE_FUNCTION_BODY += __CPROVER_file_local_s2n_hash_c_s2n_evp_hash_free
+REMOVE_FUNCTION_BODY += __CPROVER_file_local_s2n_hash_c_s2n_evp_hash_new
+REMOVE_FUNCTION_BODY += __CPROVER_file_local_s2n_hash_c_s2n_low_level_hash_free
+REMOVE_FUNCTION_BODY += __CPROVER_file_local_s2n_hash_c_s2n_low_level_hash_new
+
+UNWINDSET +=
+
+include ../Makefile.common

--- a/tests/cbmc/proofs/s2n_hash_update/Makefile
+++ b/tests/cbmc/proofs/s2n_hash_update/Makefile
@@ -1,4 +1,3 @@
-# Copyright Amazon.com, Inc. or its affiliates. All Rights Reserved.
 #
 # Licensed under the Apache License, Version 2.0 (the "License"). You may not use
 # this file except in compliance with the License. A copy of the License is

--- a/tests/cbmc/proofs/s2n_hash_update/Makefile.backup
+++ b/tests/cbmc/proofs/s2n_hash_update/Makefile.backup
@@ -1,0 +1,44 @@
+# Copyright Amazon.com, Inc. or its affiliates. All Rights Reserved.
+#
+# Licensed under the Apache License, Version 2.0 (the "License"). You may not use
+# this file except in compliance with the License. A copy of the License is
+# located at
+#
+#     http://aws.amazon.com/apache2.0/
+#
+# or in the "license" file accompanying this file. This file is distributed on an
+# "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or
+# implied. See the License for the specific language governing permissions and
+# limitations under the License.
+
+# Expected runtime is less than a minute.
+
+CBMCFLAGS +=
+
+PROOF_UID = s2n_hash_update
+HARNESS_ENTRY = $(PROOF_UID)_harness
+HARNESS_FILE = $(HARNESS_ENTRY).c
+
+PROOF_SOURCES += $(PROOFDIR)/$(HARNESS_FILE)
+PROOF_SOURCES += $(OPENSSL_SOURCE)/bn_override.c
+PROOF_SOURCES += $(OPENSSL_SOURCE)/ec_override.c
+PROOF_SOURCES += $(OPENSSL_SOURCE)/evp_override.c
+PROOF_SOURCES += $(OPENSSL_SOURCE)/md5_override.c
+PROOF_SOURCES += $(OPENSSL_SOURCE)/sha_override.c
+PROOF_SOURCES += $(PROOF_SOURCE)/make_common_datastructures.c
+PROOF_SOURCES += $(PROOF_STUB)/s2n_calculate_stacktrace.c
+PROOF_SOURCES += $(PROOF_STUB)/s2n_is_in_fips_mode.c
+
+PROJECT_SOURCES += $(SRCDIR)/crypto/s2n_hash.c
+PROJECT_SOURCES += $(SRCDIR)/crypto/s2n_evp.c
+PROJECT_SOURCES += $(SRCDIR)/utils/s2n_result.c
+PROJECT_SOURCES += $(SRCDIR)/utils/s2n_safety.c
+
+# We abstract these functions because manual inspection demonstrates they are unreachable.
+REMOVE_FUNCTION_BODY += __CPROVER_file_local_s2n_hash_c_s2n_evp_hash_digest
+REMOVE_FUNCTION_BODY += __CPROVER_file_local_s2n_hash_c_s2n_hash_digest_size
+REMOVE_FUNCTION_BODY += __CPROVER_file_local_s2n_hash_c_s2n_low_level_hash_digest
+
+UNWINDSET +=
+
+include ../Makefile.common

--- a/tests/cbmc/proofs/s2n_hex_string_to_bytes/Makefile
+++ b/tests/cbmc/proofs/s2n_hex_string_to_bytes/Makefile
@@ -1,4 +1,3 @@
-# Copyright Amazon.com, Inc. or its affiliates. All Rights Reserved.
 #
 # Licensed under the Apache License, Version 2.0 (the "License"). You may not use
 # this file except in compliance with the License. A copy of the License is

--- a/tests/cbmc/proofs/s2n_hex_string_to_bytes/Makefile.backup
+++ b/tests/cbmc/proofs/s2n_hex_string_to_bytes/Makefile.backup
@@ -1,0 +1,48 @@
+# Copyright Amazon.com, Inc. or its affiliates. All Rights Reserved.
+#
+# Licensed under the Apache License, Version 2.0 (the "License"). You may not use
+# this file except in compliance with the License. A copy of the License is
+# located at
+#
+#     http://aws.amazon.com/apache2.0/
+#
+# or in the "license" file accompanying this file. This file is distributed on an
+# "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or
+# implied. See the License for the specific language governing permissions and
+# limitations under the License.
+
+# Enough to get full coverage with 10 seconds of runtime.
+MAX_STRING_LEN = 10
+DEFINES += -DMAX_STRING_LEN=$(MAX_STRING_LEN)
+
+CBMCFLAGS +=
+
+PROOF_UID = s2n_hex_string_to_bytes
+HARNESS_ENTRY = $(PROOF_UID)_harness
+HARNESS_FILE = $(HARNESS_ENTRY).c
+
+PROOF_SOURCES += $(PROOFDIR)/$(HARNESS_FILE)
+PROOF_SOURCES += $(PROOF_SOURCE)/cbmc_utils.c
+PROOF_SOURCES += $(PROOF_SOURCE)/make_common_datastructures.c
+
+PROJECT_SOURCES += $(SRCDIR)/utils/s2n_blob.c
+PROJECT_SOURCES += $(SRCDIR)/utils/s2n_safety.c
+PROJECT_SOURCES += $(SRCDIR)/error/s2n_errno.c
+PROJECT_SOURCES += $(SRCDIR)/utils/s2n_result.c
+
+# We abstract this function because manual inspection demonstrates it is unreachable.
+REMOVE_FUNCTION_BODY += s2n_calculate_stacktrace
+
+UNWINDSET += strlen.0:$(shell echo $$((1 + $(MAX_STRING_LEN))))
+UNWINDSET += s2n_hex_string_to_bytes_harness.0:$(shell echo $$((1 + $(MAX_STRING_LEN))))
+UNWINDSET += s2n_hex_string_to_bytes.2:$(shell echo $$((1 + $(MAX_STRING_LEN))))
+UNWINDSET += s2n_hex_string_to_bytes.3:$(shell echo $$((1 + $(MAX_STRING_LEN))))
+UNWINDSET += s2n_hex_string_to_bytes.6:$(shell echo $$((1 + $(MAX_STRING_LEN))))
+UNWINDSET += s2n_hex_string_to_bytes.9:$(shell echo $$((1 + $(MAX_STRING_LEN))))
+UNWINDSET += s2n_hex_string_to_bytes.12:$(shell echo $$((1 + $(MAX_STRING_LEN))))
+UNWINDSET += s2n_hex_string_to_bytes.13:$(shell echo $$((1 + $(MAX_STRING_LEN))))
+UNWINDSET += s2n_hex_string_to_bytes.15:$(shell echo $$((1 + $(MAX_STRING_LEN))))
+UNWINDSET += s2n_hex_string_to_bytes.16:$(shell echo $$((1 + $(MAX_STRING_LEN))))
+UNWINDSET += s2n_hex_string_to_bytes.17:$(shell echo $$((1 + $(MAX_STRING_LEN))))
+
+include ../Makefile.common

--- a/tests/cbmc/proofs/s2n_hmac_copy/Makefile
+++ b/tests/cbmc/proofs/s2n_hmac_copy/Makefile
@@ -1,4 +1,3 @@
-# Copyright Amazon.com, Inc. or its affiliates. All Rights Reserved.
 #
 # Licensed under the Apache License, Version 2.0 (the "License"). You may not use
 # this file except in compliance with the License. A copy of the License is

--- a/tests/cbmc/proofs/s2n_hmac_copy/Makefile.backup
+++ b/tests/cbmc/proofs/s2n_hmac_copy/Makefile.backup
@@ -1,0 +1,49 @@
+# Copyright Amazon.com, Inc. or its affiliates. All Rights Reserved.
+#
+# Licensed under the Apache License, Version 2.0 (the "License"). You may not use
+# this file except in compliance with the License. A copy of the License is
+# located at
+#
+#     http://aws.amazon.com/apache2.0/
+#
+# or in the "license" file accompanying this file. This file is distributed on an
+# "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or
+# implied. See the License for the specific language governing permissions and
+# limitations under the License.
+
+# Expected runtime is less than 2 minutes.
+
+CBMCFLAGS +=
+
+PROOF_UID = s2n_hmac_copy
+HARNESS_ENTRY = $(PROOF_UID)_harness
+HARNESS_FILE = $(HARNESS_ENTRY).c
+
+PROOF_SOURCES += $(OPENSSL_SOURCE)/bn_override.c
+PROOF_SOURCES += $(OPENSSL_SOURCE)/ec_override.c
+PROOF_SOURCES += $(OPENSSL_SOURCE)/evp_override.c
+PROOF_SOURCES += $(PROOF_SOURCE)/make_common_datastructures.c
+PROOF_SOURCES += $(PROOF_STUB)/s2n_calculate_stacktrace.c
+PROOF_SOURCES += $(PROOF_STUB)/s2n_is_in_fips_mode.c
+PROOF_SOURCES += $(PROOFDIR)/$(HARNESS_FILE)
+
+PROJECT_SOURCES += $(SRCDIR)/crypto/s2n_hash.c
+PROJECT_SOURCES += $(SRCDIR)/crypto/s2n_hmac.c
+PROJECT_SOURCES += $(SRCDIR)/crypto/s2n_evp.c
+PROJECT_SOURCES += $(SRCDIR)/utils/s2n_ensure.c
+PROJECT_SOURCES += $(SRCDIR)/utils/s2n_result.c
+PROJECT_SOURCES += $(SRCDIR)/utils/s2n_safety.c
+
+# We abstract these functions because manual inspection demonstrates they are unreachable.
+REMOVE_FUNCTION_BODY += __CPROVER_file_local_s2n_hash_c_s2n_evp_hash_free
+REMOVE_FUNCTION_BODY += __CPROVER_file_local_s2n_hash_c_s2n_evp_hash_init
+REMOVE_FUNCTION_BODY += __CPROVER_file_local_s2n_hash_c_s2n_evp_hash_new
+REMOVE_FUNCTION_BODY += __CPROVER_file_local_s2n_hash_c_s2n_evp_hash_reset
+REMOVE_FUNCTION_BODY += __CPROVER_file_local_s2n_hash_c_s2n_low_level_hash_free
+REMOVE_FUNCTION_BODY += __CPROVER_file_local_s2n_hash_c_s2n_low_level_hash_init
+REMOVE_FUNCTION_BODY += __CPROVER_file_local_s2n_hash_c_s2n_low_level_hash_new
+REMOVE_FUNCTION_BODY += __CPROVER_file_local_s2n_hash_c_s2n_low_level_hash_reset
+
+UNWINDSET +=
+
+include ../Makefile.common

--- a/tests/cbmc/proofs/s2n_hmac_digest/Makefile
+++ b/tests/cbmc/proofs/s2n_hmac_digest/Makefile
@@ -1,4 +1,3 @@
-# Copyright Amazon.com, Inc. or its affiliates. All Rights Reserved.
 #
 # Licensed under the Apache License, Version 2.0 (the "License"). You may not use
 # this file except in compliance with the License. A copy of the License is

--- a/tests/cbmc/proofs/s2n_hmac_digest/Makefile.backup
+++ b/tests/cbmc/proofs/s2n_hmac_digest/Makefile.backup
@@ -1,0 +1,34 @@
+# Copyright Amazon.com, Inc. or its affiliates. All Rights Reserved.
+#
+# Licensed under the Apache License, Version 2.0 (the "License"). You may not use
+# this file except in compliance with the License. A copy of the License is
+# located at
+#
+#     http://aws.amazon.com/apache2.0/
+#
+# or in the "license" file accompanying this file. This file is distributed on an
+# "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or
+# implied. See the License for the specific language governing permissions and
+# limitations under the License.
+
+# Expected runtime is less than 2 minutes.
+
+PROOF_UID = s2n_hmac_digest
+HARNESS_ENTRY = $(PROOF_UID)_harness
+HARNESS_FILE = $(HARNESS_ENTRY).c
+
+PROOF_SOURCES += $(PROOF_SOURCE)/make_common_datastructures.c
+PROOF_SOURCES += $(PROOF_STUB)/s2n_calculate_stacktrace.c
+PROOF_SOURCES += $(PROOF_STUB)/s2n_is_in_fips_mode.c
+PROOF_SOURCES += $(PROOF_STUB)/s2n_hash_copy.c
+PROOF_SOURCES += $(PROOF_STUB)/s2n_hash_digest.c
+PROOF_SOURCES += $(PROOF_STUB)/s2n_hash_update.c
+PROOF_SOURCES += $(PROOFDIR)/$(HARNESS_FILE)
+
+PROJECT_SOURCES += $(SRCDIR)/crypto/s2n_hash.c
+PROJECT_SOURCES += $(SRCDIR)/crypto/s2n_hmac.c
+PROJECT_SOURCES += $(SRCDIR)/utils/s2n_result.c
+
+UNWINDSET +=
+
+include ../Makefile.common

--- a/tests/cbmc/proofs/s2n_hmac_digest_size/Makefile
+++ b/tests/cbmc/proofs/s2n_hmac_digest_size/Makefile
@@ -1,4 +1,3 @@
-# Copyright Amazon.com, Inc. or its affiliates. All Rights Reserved.
 #
 # Licensed under the Apache License, Version 2.0 (the "License"). You may not use
 # this file except in compliance with the License. A copy of the License is

--- a/tests/cbmc/proofs/s2n_hmac_digest_size/Makefile.backup
+++ b/tests/cbmc/proofs/s2n_hmac_digest_size/Makefile.backup
@@ -1,0 +1,30 @@
+# Copyright Amazon.com, Inc. or its affiliates. All Rights Reserved.
+#
+# Licensed under the Apache License, Version 2.0 (the "License"). You may not use
+# this file except in compliance with the License. A copy of the License is
+# located at
+#
+#     http://aws.amazon.com/apache2.0/
+#
+# or in the "license" file accompanying this file. This file is distributed on an
+# "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or
+# implied. See the License for the specific language governing permissions and
+# limitations under the License.
+
+# Expected runtime is less than 5 seconds.
+
+CBMCFLAGS +=
+
+PROOF_UID = s2n_hmac_digest_size
+HARNESS_ENTRY = $(PROOF_UID)_harness
+HARNESS_FILE = $(HARNESS_ENTRY).c
+
+PROOF_SOURCES += $(PROOFDIR)/$(HARNESS_FILE)
+PROOF_SOURCES += $(PROOF_STUB)/s2n_calculate_stacktrace.c
+
+PROJECT_SOURCES += $(SRCDIR)/crypto/s2n_hash.c
+PROJECT_SOURCES += $(SRCDIR)/crypto/s2n_hmac.c
+
+UNWINDSET +=
+
+include ../Makefile.common

--- a/tests/cbmc/proofs/s2n_hmac_digest_two_compression_rounds/Makefile
+++ b/tests/cbmc/proofs/s2n_hmac_digest_two_compression_rounds/Makefile
@@ -1,4 +1,3 @@
-# Copyright Amazon.com, Inc. or its affiliates. All Rights Reserved.
 #
 # Licensed under the Apache License, Version 2.0 (the "License"). You may not use
 # this file except in compliance with the License. A copy of the License is

--- a/tests/cbmc/proofs/s2n_hmac_digest_two_compression_rounds/Makefile.backup
+++ b/tests/cbmc/proofs/s2n_hmac_digest_two_compression_rounds/Makefile.backup
@@ -1,0 +1,35 @@
+# Copyright Amazon.com, Inc. or its affiliates. All Rights Reserved.
+#
+# Licensed under the Apache License, Version 2.0 (the "License"). You may not use
+# this file except in compliance with the License. A copy of the License is
+# located at
+#
+#     http://aws.amazon.com/apache2.0/
+#
+# or in the "license" file accompanying this file. This file is distributed on an
+# "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or
+# implied. See the License for the specific language governing permissions and
+# limitations under the License.
+
+# Expected runtime is less than 2 minutes.
+
+PROOF_UID = s2n_hmac_digest_two_compression_rounds
+HARNESS_ENTRY = $(PROOF_UID)_harness
+HARNESS_FILE = $(HARNESS_ENTRY).c
+
+PROOF_SOURCES += $(PROOF_SOURCE)/make_common_datastructures.c
+PROOF_SOURCES += $(PROOF_STUB)/s2n_calculate_stacktrace.c
+PROOF_SOURCES += $(PROOF_STUB)/s2n_is_in_fips_mode.c
+PROOF_SOURCES += $(PROOF_STUB)/s2n_hash_copy.c
+PROOF_SOURCES += $(PROOF_STUB)/s2n_hash_digest.c
+PROOF_SOURCES += $(PROOF_STUB)/s2n_hash_reset.c
+PROOF_SOURCES += $(PROOF_STUB)/s2n_hash_update.c
+PROOF_SOURCES += $(PROOFDIR)/$(HARNESS_FILE)
+
+PROJECT_SOURCES += $(SRCDIR)/crypto/s2n_hash.c
+PROJECT_SOURCES += $(SRCDIR)/crypto/s2n_hmac.c
+PROJECT_SOURCES += $(SRCDIR)/utils/s2n_result.c
+
+UNWINDSET +=
+
+include ../Makefile.common

--- a/tests/cbmc/proofs/s2n_hmac_digest_verify/Makefile
+++ b/tests/cbmc/proofs/s2n_hmac_digest_verify/Makefile
@@ -1,4 +1,3 @@
-# Copyright Amazon.com, Inc. or its affiliates. All Rights Reserved.
 #
 # Licensed under the Apache License, Version 2.0 (the "License"). You may not use
 # this file except in compliance with the License. A copy of the License is

--- a/tests/cbmc/proofs/s2n_hmac_digest_verify/Makefile.backup
+++ b/tests/cbmc/proofs/s2n_hmac_digest_verify/Makefile.backup
@@ -1,0 +1,31 @@
+# Copyright Amazon.com, Inc. or its affiliates. All Rights Reserved.
+#
+# Licensed under the Apache License, Version 2.0 (the "License"). You may not use
+# this file except in compliance with the License. A copy of the License is
+# located at
+#
+#     http://aws.amazon.com/apache2.0/
+#
+# or in the "license" file accompanying this file. This file is distributed on an
+# "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or
+# implied. See the License for the specific language governing permissions and
+# limitations under the License.
+
+# Expected runtime is 6 seconds.
+MAX_ARR_LEN = 10
+DEFINES += -DMAX_ARR_LEN=$(MAX_ARR_LEN)
+
+CBMCFLAGS +=
+
+PROOF_UID = s2n_hmac_digest_verify
+HARNESS_ENTRY = $(PROOF_UID)_harness
+HARNESS_FILE = $(HARNESS_ENTRY).c
+
+PROOF_SOURCES += $(PROOFDIR)/$(HARNESS_FILE)
+
+PROJECT_SOURCES += $(SRCDIR)/crypto/s2n_hmac.c
+PROJECT_SOURCES += $(SRCDIR)/utils/s2n_safety.c
+
+UNWINDSET += s2n_constant_time_equals.0:$(call addone,$(MAX_ARR_LEN))
+
+include ../Makefile.common

--- a/tests/cbmc/proofs/s2n_hmac_free/Makefile
+++ b/tests/cbmc/proofs/s2n_hmac_free/Makefile
@@ -1,4 +1,3 @@
-# Copyright Amazon.com, Inc. or its affiliates. All Rights Reserved.
 #
 # Licensed under the Apache License, Version 2.0 (the "License"). You may not use
 # this file except in compliance with the License. A copy of the License is

--- a/tests/cbmc/proofs/s2n_hmac_free/Makefile.backup
+++ b/tests/cbmc/proofs/s2n_hmac_free/Makefile.backup
@@ -1,0 +1,45 @@
+# Copyright Amazon.com, Inc. or its affiliates. All Rights Reserved.
+#
+# Licensed under the Apache License, Version 2.0 (the "License"). You may not use
+# this file except in compliance with the License. A copy of the License is
+# located at
+#
+#     http://aws.amazon.com/apache2.0/
+#
+# or in the "license" file accompanying this file. This file is distributed on an
+# "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or
+# implied. See the License for the specific language governing permissions and
+# limitations under the License.
+
+# Expected runtime is less than 5 minutes.
+
+CBMCFLAGS +=
+
+PROOF_UID = s2n_hmac_free
+HARNESS_ENTRY = $(PROOF_UID)_harness
+HARNESS_FILE = $(HARNESS_ENTRY).c
+
+PROOF_SOURCES += $(OPENSSL_SOURCE)/bn_override.c
+PROOF_SOURCES += $(OPENSSL_SOURCE)/ec_override.c
+PROOF_SOURCES += $(OPENSSL_SOURCE)/evp_override.c
+PROOF_SOURCES += $(PROOF_SOURCE)/make_common_datastructures.c
+PROOF_SOURCES += $(PROOF_STUB)/s2n_is_in_fips_mode.c
+PROOF_SOURCES += $(PROOFDIR)/$(HARNESS_FILE)
+
+PROJECT_SOURCES += $(SRCDIR)/crypto/s2n_hash.c
+PROJECT_SOURCES += $(SRCDIR)/crypto/s2n_hmac.c
+PROJECT_SOURCES += $(SRCDIR)/utils/s2n_result.c
+
+# We abstract these functions because manual inspection demonstrates they are unreachable.
+REMOVE_FUNCTION_BODY += __CPROVER_file_local_s2n_hash_c_s2n_evp_hash_init
+REMOVE_FUNCTION_BODY += __CPROVER_file_local_s2n_hash_c_s2n_evp_hash_new
+REMOVE_FUNCTION_BODY += __CPROVER_file_local_s2n_hash_c_s2n_evp_hash_reset
+REMOVE_FUNCTION_BODY += __CPROVER_file_local_s2n_hash_c_s2n_low_level_hash_init
+REMOVE_FUNCTION_BODY += __CPROVER_file_local_s2n_hash_c_s2n_low_level_hash_new
+REMOVE_FUNCTION_BODY += __CPROVER_file_local_s2n_hash_c_s2n_low_level_hash_reset
+REMOVE_FUNCTION_BODY += __CPROVER_file_local_s2n_hash_c_s2n_hash_allow_md5_for_fips
+REMOVE_FUNCTION_BODY += __CPROVER_file_local_s2n_hash_c_s2n_evp_hash_allow_md5_for_fips
+
+UNWINDSET +=
+
+include ../Makefile.common

--- a/tests/cbmc/proofs/s2n_hmac_hash_alg/Makefile
+++ b/tests/cbmc/proofs/s2n_hmac_hash_alg/Makefile
@@ -1,4 +1,3 @@
-# Copyright Amazon.com, Inc. or its affiliates. All Rights Reserved.
 #
 # Licensed under the Apache License, Version 2.0 (the "License"). You may not use
 # this file except in compliance with the License. A copy of the License is

--- a/tests/cbmc/proofs/s2n_hmac_hash_alg/Makefile.backup
+++ b/tests/cbmc/proofs/s2n_hmac_hash_alg/Makefile.backup
@@ -1,0 +1,29 @@
+# Copyright Amazon.com, Inc. or its affiliates. All Rights Reserved.
+#
+# Licensed under the Apache License, Version 2.0 (the "License"). You may not use
+# this file except in compliance with the License. A copy of the License is
+# located at
+#
+#     http://aws.amazon.com/apache2.0/
+#
+# or in the "license" file accompanying this file. This file is distributed on an
+# "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or
+# implied. See the License for the specific language governing permissions and
+# limitations under the License.
+
+# Expected runtime is less than 5 seconds.
+
+CBMCFLAGS +=
+
+PROOF_UID = s2n_hmac_hash_alg
+HARNESS_ENTRY = $(PROOF_UID)_harness
+HARNESS_FILE = $(HARNESS_ENTRY).c
+
+PROOF_SOURCES += $(PROOFDIR)/$(HARNESS_FILE)
+PROOF_SOURCES += $(PROOF_STUB)/s2n_calculate_stacktrace.c
+
+PROJECT_SOURCES += $(SRCDIR)/crypto/s2n_hmac.c
+
+UNWINDSET +=
+
+include ../Makefile.common

--- a/tests/cbmc/proofs/s2n_hmac_hash_block_size/Makefile
+++ b/tests/cbmc/proofs/s2n_hmac_hash_block_size/Makefile
@@ -1,4 +1,3 @@
-# Copyright Amazon.com, Inc. or its affiliates. All Rights Reserved.
 #
 # Licensed under the Apache License, Version 2.0 (the "License"). You may not use
 # this file except in compliance with the License. A copy of the License is

--- a/tests/cbmc/proofs/s2n_hmac_hash_block_size/Makefile.backup
+++ b/tests/cbmc/proofs/s2n_hmac_hash_block_size/Makefile.backup
@@ -1,0 +1,29 @@
+# Copyright Amazon.com, Inc. or its affiliates. All Rights Reserved.
+#
+# Licensed under the Apache License, Version 2.0 (the "License"). You may not use
+# this file except in compliance with the License. A copy of the License is
+# located at
+#
+#     http://aws.amazon.com/apache2.0/
+#
+# or in the "license" file accompanying this file. This file is distributed on an
+# "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or
+# implied. See the License for the specific language governing permissions and
+# limitations under the License.
+
+# Expected runtime is less than 5 seconds.
+
+CBMCFLAGS +=
+
+PROOF_UID = s2n_hmac_hash_block_size
+HARNESS_ENTRY = $(PROOF_UID)_harness
+HARNESS_FILE = $(HARNESS_ENTRY).c
+
+PROOF_SOURCES += $(PROOFDIR)/$(HARNESS_FILE)
+PROOF_SOURCES += $(PROOF_STUB)/s2n_calculate_stacktrace.c
+
+PROJECT_SOURCES += $(SRCDIR)/crypto/s2n_hmac.c
+
+UNWINDSET +=
+
+include ../Makefile.common

--- a/tests/cbmc/proofs/s2n_hmac_init/Makefile
+++ b/tests/cbmc/proofs/s2n_hmac_init/Makefile
@@ -1,4 +1,3 @@
-# Copyright Amazon.com, Inc. or its affiliates. All Rights Reserved.
 #
 # Licensed under the Apache License, Version 2.0 (the "License"). You may not use
 # this file except in compliance with the License. A copy of the License is

--- a/tests/cbmc/proofs/s2n_hmac_init/Makefile.backup
+++ b/tests/cbmc/proofs/s2n_hmac_init/Makefile.backup
@@ -1,0 +1,66 @@
+# Copyright Amazon.com, Inc. or its affiliates. All Rights Reserved.
+#
+# Licensed under the Apache License, Version 2.0 (the "License"). You may not use
+# this file except in compliance with the License. A copy of the License is
+# located at
+#
+#     http://aws.amazon.com/apache2.0/
+#
+# or in the "license" file accompanying this file. This file is distributed on an
+# "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or
+# implied. See the License for the specific language governing permissions and
+# limitations under the License.
+
+CBMCFLAGS +=
+
+PROOF_UID = s2n_hmac_init
+HARNESS_ENTRY = $(PROOF_UID)_harness
+HARNESS_FILE = $(HARNESS_ENTRY).c
+
+PROOF_SOURCES += $(OPENSSL_SOURCE)/evp_override.c
+PROOF_SOURCES += $(OPENSSL_SOURCE)/md5_override.c
+PROOF_SOURCES += $(OPENSSL_SOURCE)/sha_override.c
+PROOF_SOURCES += $(PROOF_SOURCE)/make_common_datastructures.c
+PROOF_SOURCES += $(PROOF_STUB)/s2n_calculate_stacktrace.c
+PROOF_SOURCES += $(PROOF_STUB)/s2n_is_in_fips_mode.c
+PROOF_SOURCES += $(PROOFDIR)/$(HARNESS_FILE)
+
+PROJECT_SOURCES += $(SRCDIR)/crypto/s2n_hash.c
+PROJECT_SOURCES += $(SRCDIR)/crypto/s2n_hmac.c
+PROJECT_SOURCES += $(SRCDIR)/crypto/s2n_evp.c
+PROJECT_SOURCES += $(SRCDIR)/utils/s2n_ensure.c
+PROJECT_SOURCES += $(SRCDIR)/utils/s2n_result.c
+
+# We abstract these functions because manual inspection demonstrates they are unreachable.
+REMOVE_FUNCTION_BODY += __CPROVER_file_local_s2n_hash_c_s2n_low_level_hash_new
+REMOVE_FUNCTION_BODY += __CPROVER_file_local_s2n_hash_c_s2n_low_level_hash_reset
+REMOVE_FUNCTION_BODY += __CPROVER_file_local_s2n_hash_c_s2n_low_level_hash_free
+REMOVE_FUNCTION_BODY += __CPROVER_file_local_s2n_hash_c_s2n_low_level_hash_digest
+REMOVE_FUNCTION_BODY += __CPROVER_file_local_s2n_hash_c_s2n_low_level_hash_update
+REMOVE_FUNCTION_BODY += __CPROVER_file_local_s2n_hash_c_s2n_evp_hash_free
+REMOVE_FUNCTION_BODY += __CPROVER_file_local_s2n_hash_c_s2n_evp_hash_new
+REMOVE_FUNCTION_BODY += __CPROVER_file_local_s2n_hash_c_s2n_evp_hash_reset
+REMOVE_FUNCTION_BODY += __CPROVER_file_local_s2n_hash_c_s2n_evp_hash_digest
+REMOVE_FUNCTION_BODY += __CPROVER_file_local_s2n_hash_c_s2n_evp_hash_update
+REMOVE_FUNCTION_BODY += __CPROVER_file_local_s2n_hash_c_s2n_evp_hash_allow_md5_for_fips
+REMOVE_FUNCTION_BODY += s2n_hash_allow_md5_for_fips
+
+# The upper bound limit for these loops is me maximum possible value for xor_pad_size field
+# in struct s2n_hmac_state (128) plus one. See definition for struct s2n_hmac_state
+UNWINDSET += __CPROVER_file_local_s2n_hmac_c_s2n_sslv3_mac_init.0:129
+UNWINDSET += __CPROVER_file_local_s2n_hmac_c_s2n_sslv3_mac_init.1:129
+UNWINDSET += __CPROVER_file_local_s2n_hmac_c_s2n_sslv3_mac_init.2:129
+UNWINDSET += __CPROVER_file_local_s2n_hmac_c_s2n_sslv3_mac_init.3:129
+UNWINDSET += __CPROVER_file_local_s2n_hmac_c_s2n_sslv3_mac_init.4:129
+UNWINDSET += __CPROVER_file_local_s2n_hmac_c_s2n_sslv3_mac_init.5:129
+UNWINDSET += __CPROVER_file_local_s2n_hmac_c_s2n_tls_hmac_init.0:129
+UNWINDSET += __CPROVER_file_local_s2n_hmac_c_s2n_tls_hmac_init.1:129
+UNWINDSET += __CPROVER_file_local_s2n_hmac_c_s2n_tls_hmac_init.2:129
+UNWINDSET += __CPROVER_file_local_s2n_hmac_c_s2n_tls_hmac_init.3:129
+UNWINDSET += __CPROVER_file_local_s2n_hmac_c_s2n_tls_hmac_init.4:129
+UNWINDSET += __CPROVER_file_local_s2n_hmac_c_s2n_tls_hmac_init.5:129
+UNWINDSET += __CPROVER_file_local_s2n_hmac_c_s2n_tls_hmac_init.6:129
+UNWINDSET += __CPROVER_file_local_s2n_hmac_c_s2n_tls_hmac_init.8:129
+UNWINDSET += __CPROVER_file_local_s2n_hmac_c_s2n_tls_hmac_init.9:129
+
+include ../Makefile.common

--- a/tests/cbmc/proofs/s2n_hmac_is_available/Makefile
+++ b/tests/cbmc/proofs/s2n_hmac_is_available/Makefile
@@ -1,4 +1,3 @@
-# Copyright Amazon.com, Inc. or its affiliates. All Rights Reserved.
 #
 # Licensed under the Apache License, Version 2.0 (the "License"). You may not use
 # this file except in compliance with the License. A copy of the License is

--- a/tests/cbmc/proofs/s2n_hmac_is_available/Makefile.backup
+++ b/tests/cbmc/proofs/s2n_hmac_is_available/Makefile.backup
@@ -1,0 +1,30 @@
+# Copyright Amazon.com, Inc. or its affiliates. All Rights Reserved.
+#
+# Licensed under the Apache License, Version 2.0 (the "License"). You may not use
+# this file except in compliance with the License. A copy of the License is
+# located at
+#
+#     http://aws.amazon.com/apache2.0/
+#
+# or in the "license" file accompanying this file. This file is distributed on an
+# "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or
+# implied. See the License for the specific language governing permissions and
+# limitations under the License.
+
+# Expected runtime is less than 5 seconds.
+
+CBMCFLAGS +=
+
+PROOF_UID = s2n_hmac_is_available
+HARNESS_ENTRY = $(PROOF_UID)_harness
+HARNESS_FILE = $(HARNESS_ENTRY).c
+
+PROOF_SOURCES += $(PROOFDIR)/$(HARNESS_FILE)
+PROOF_SOURCES += $(PROOF_STUB)/s2n_calculate_stacktrace.c
+PROOF_SOURCES += $(PROOF_STUB)/s2n_is_in_fips_mode.c
+
+PROJECT_SOURCES += $(SRCDIR)/crypto/s2n_hmac.c
+
+UNWINDSET +=
+
+include ../Makefile.common

--- a/tests/cbmc/proofs/s2n_hmac_new/Makefile
+++ b/tests/cbmc/proofs/s2n_hmac_new/Makefile
@@ -1,4 +1,3 @@
-# Copyright Amazon.com, Inc. or its affiliates. All Rights Reserved.
 #
 # Licensed under the Apache License, Version 2.0 (the "License"). You may not use
 # this file except in compliance with the License. A copy of the License is

--- a/tests/cbmc/proofs/s2n_hmac_new/Makefile.backup
+++ b/tests/cbmc/proofs/s2n_hmac_new/Makefile.backup
@@ -1,0 +1,43 @@
+# Copyright Amazon.com, Inc. or its affiliates. All Rights Reserved.
+#
+# Licensed under the Apache License, Version 2.0 (the "License"). You may not use
+# this file except in compliance with the License. A copy of the License is
+# located at
+#
+#     http://aws.amazon.com/apache2.0/
+#
+# or in the "license" file accompanying this file. This file is distributed on an
+# "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or
+# implied. See the License for the specific language governing permissions and
+# limitations under the License.
+
+# Expected runtime is less than 5 seconds.
+
+CBMCFLAGS +=
+
+PROOF_UID = s2n_hmac_new
+HARNESS_ENTRY = $(PROOF_UID)_harness
+HARNESS_FILE = $(HARNESS_ENTRY).c
+
+PROOF_SOURCES += $(OPENSSL_SOURCE)/evp_override.c
+PROOF_SOURCES += $(PROOF_SOURCE)/make_common_datastructures.c
+PROOF_SOURCES += $(PROOF_STUB)/s2n_is_in_fips_mode.c
+PROOF_SOURCES += $(PROOFDIR)/$(HARNESS_FILE)
+
+PROJECT_SOURCES += $(SRCDIR)/crypto/s2n_hash.c
+PROJECT_SOURCES += $(SRCDIR)/crypto/s2n_hmac.c
+PROJECT_SOURCES += $(SRCDIR)/crypto/s2n_evp.c
+PROJECT_SOURCES += $(SRCDIR)/utils/s2n_result.c
+
+# We abstract these functions because manual inspection demonstrates they are unreachable.
+REMOVE_FUNCTION_BODY += __CPROVER_file_local_s2n_hash_c_s2n_low_level_hash_init
+REMOVE_FUNCTION_BODY += __CPROVER_file_local_s2n_hash_c_s2n_low_level_hash_reset
+REMOVE_FUNCTION_BODY += __CPROVER_file_local_s2n_hash_c_s2n_low_level_hash_free
+REMOVE_FUNCTION_BODY += __CPROVER_file_local_s2n_hash_c_s2n_evp_hash_allow_md5_for_fips
+REMOVE_FUNCTION_BODY += __CPROVER_file_local_s2n_hash_c_s2n_evp_hash_init
+REMOVE_FUNCTION_BODY += __CPROVER_file_local_s2n_hash_c_s2n_evp_hash_reset
+REMOVE_FUNCTION_BODY += __CPROVER_file_local_s2n_hash_c_s2n_evp_hash_free
+
+UNWINDSET +=
+
+include ../Makefile.common

--- a/tests/cbmc/proofs/s2n_hmac_reset/Makefile
+++ b/tests/cbmc/proofs/s2n_hmac_reset/Makefile
@@ -1,4 +1,3 @@
-# Copyright Amazon.com, Inc. or its affiliates. All Rights Reserved.
 #
 # Licensed under the Apache License, Version 2.0 (the "License"). You may not use
 # this file except in compliance with the License. A copy of the License is

--- a/tests/cbmc/proofs/s2n_hmac_reset/Makefile.backup
+++ b/tests/cbmc/proofs/s2n_hmac_reset/Makefile.backup
@@ -1,0 +1,49 @@
+# Copyright Amazon.com, Inc. or its affiliates. All Rights Reserved.
+#
+# Licensed under the Apache License, Version 2.0 (the "License"). You may not use
+# this file except in compliance with the License. A copy of the License is
+# located at
+#
+#     http://aws.amazon.com/apache2.0/
+#
+# or in the "license" file accompanying this file. This file is distributed on an
+# "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or
+# implied. See the License for the specific language governing permissions and
+# limitations under the License.
+
+# Expected runtime is less than 2 minutes.
+
+CBMCFLAGS +=
+
+PROOF_UID = s2n_hmac_reset
+HARNESS_ENTRY = $(PROOF_UID)_harness
+HARNESS_FILE = $(HARNESS_ENTRY).c
+
+PROOF_SOURCES += $(OPENSSL_SOURCE)/bn_override.c
+PROOF_SOURCES += $(OPENSSL_SOURCE)/ec_override.c
+PROOF_SOURCES += $(OPENSSL_SOURCE)/evp_override.c
+PROOF_SOURCES += $(PROOF_SOURCE)/make_common_datastructures.c
+PROOF_SOURCES += $(PROOF_STUB)/s2n_calculate_stacktrace.c
+PROOF_SOURCES += $(PROOF_STUB)/s2n_is_in_fips_mode.c
+PROOF_SOURCES += $(PROOFDIR)/$(HARNESS_FILE)
+
+PROJECT_SOURCES += $(SRCDIR)/crypto/s2n_hash.c
+PROJECT_SOURCES += $(SRCDIR)/crypto/s2n_hmac.c
+PROJECT_SOURCES += $(SRCDIR)/crypto/s2n_evp.c
+PROJECT_SOURCES += $(SRCDIR)/utils/s2n_ensure.c
+PROJECT_SOURCES += $(SRCDIR)/utils/s2n_result.c
+PROJECT_SOURCES += $(SRCDIR)/utils/s2n_safety.c
+
+# We abstract these functions because manual inspection demonstrates they are unreachable.
+REMOVE_FUNCTION_BODY += __CPROVER_file_local_s2n_hash_c_s2n_evp_hash_free
+REMOVE_FUNCTION_BODY += __CPROVER_file_local_s2n_hash_c_s2n_evp_hash_init
+REMOVE_FUNCTION_BODY += __CPROVER_file_local_s2n_hash_c_s2n_evp_hash_new
+REMOVE_FUNCTION_BODY += __CPROVER_file_local_s2n_hash_c_s2n_evp_hash_reset
+REMOVE_FUNCTION_BODY += __CPROVER_file_local_s2n_hash_c_s2n_low_level_hash_free
+REMOVE_FUNCTION_BODY += __CPROVER_file_local_s2n_hash_c_s2n_low_level_hash_init
+REMOVE_FUNCTION_BODY += __CPROVER_file_local_s2n_hash_c_s2n_low_level_hash_new
+REMOVE_FUNCTION_BODY += __CPROVER_file_local_s2n_hash_c_s2n_low_level_hash_reset
+
+UNWINDSET +=
+
+include ../Makefile.common

--- a/tests/cbmc/proofs/s2n_hmac_restore_evp_hash_state/Makefile
+++ b/tests/cbmc/proofs/s2n_hmac_restore_evp_hash_state/Makefile
@@ -1,4 +1,3 @@
-# Copyright Amazon.com, Inc. or its affiliates. All Rights Reserved.
 #
 # Licensed under the Apache License, Version 2.0 (the "License"). You may not use
 # this file except in compliance with the License. A copy of the License is

--- a/tests/cbmc/proofs/s2n_hmac_restore_evp_hash_state/Makefile.backup
+++ b/tests/cbmc/proofs/s2n_hmac_restore_evp_hash_state/Makefile.backup
@@ -1,0 +1,33 @@
+# Copyright Amazon.com, Inc. or its affiliates. All Rights Reserved.
+#
+# Licensed under the Apache License, Version 2.0 (the "License"). You may not use
+# this file except in compliance with the License. A copy of the License is
+# located at
+#
+#     http://aws.amazon.com/apache2.0/
+#
+# or in the "license" file accompanying this file. This file is distributed on an
+# "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or
+# implied. See the License for the specific language governing permissions and
+# limitations under the License.
+
+# Expected runtime is less than 5 seconds.
+
+CBMCFLAGS +=
+
+PROOF_UID = s2n_hmac_restore_evp_hash_state
+HARNESS_ENTRY = $(PROOF_UID)_harness
+HARNESS_FILE = $(HARNESS_ENTRY).c
+
+PROOF_SOURCES += $(PROOFDIR)/$(HARNESS_FILE)
+PROOF_SOURCES += $(PROOF_SOURCE)/make_common_datastructures.c
+PROOF_SOURCES += $(PROOF_STUB)/s2n_calculate_stacktrace.c
+PROOF_SOURCES += $(PROOF_STUB)/s2n_is_in_fips_mode.c
+
+PROJECT_SOURCES += $(SRCDIR)/crypto/s2n_hash.c
+PROJECT_SOURCES += $(SRCDIR)/crypto/s2n_hmac.c
+PROJECT_SOURCES += $(SRCDIR)/utils/s2n_result.c
+
+UNWINDSET +=
+
+include ../Makefile.common

--- a/tests/cbmc/proofs/s2n_hmac_save_evp_hash_state/Makefile
+++ b/tests/cbmc/proofs/s2n_hmac_save_evp_hash_state/Makefile
@@ -1,4 +1,3 @@
-# Copyright Amazon.com, Inc. or its affiliates. All Rights Reserved.
 #
 # Licensed under the Apache License, Version 2.0 (the "License"). You may not use
 # this file except in compliance with the License. A copy of the License is

--- a/tests/cbmc/proofs/s2n_hmac_save_evp_hash_state/Makefile.backup
+++ b/tests/cbmc/proofs/s2n_hmac_save_evp_hash_state/Makefile.backup
@@ -1,0 +1,33 @@
+# Copyright Amazon.com, Inc. or its affiliates. All Rights Reserved.
+#
+# Licensed under the Apache License, Version 2.0 (the "License"). You may not use
+# this file except in compliance with the License. A copy of the License is
+# located at
+#
+#     http://aws.amazon.com/apache2.0/
+#
+# or in the "license" file accompanying this file. This file is distributed on an
+# "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or
+# implied. See the License for the specific language governing permissions and
+# limitations under the License.
+
+# Expected runtime is less than 5 seconds.
+
+CBMCFLAGS +=
+
+PROOF_UID = s2n_hmac_save_evp_hash_state
+HARNESS_ENTRY = $(PROOF_UID)_harness
+HARNESS_FILE = $(HARNESS_ENTRY).c
+
+PROOF_SOURCES += $(PROOFDIR)/$(HARNESS_FILE)
+PROOF_SOURCES += $(PROOF_SOURCE)/make_common_datastructures.c
+PROOF_SOURCES += $(PROOF_STUB)/s2n_calculate_stacktrace.c
+PROOF_SOURCES += $(PROOF_STUB)/s2n_is_in_fips_mode.c
+
+PROJECT_SOURCES += $(SRCDIR)/crypto/s2n_hash.c
+PROJECT_SOURCES += $(SRCDIR)/crypto/s2n_hmac.c
+PROJECT_SOURCES += $(SRCDIR)/utils/s2n_result.c
+
+UNWINDSET +=
+
+include ../Makefile.common

--- a/tests/cbmc/proofs/s2n_hmac_update/Makefile
+++ b/tests/cbmc/proofs/s2n_hmac_update/Makefile
@@ -1,4 +1,3 @@
-# Copyright Amazon.com, Inc. or its affiliates. All Rights Reserved.
 #
 # Licensed under the Apache License, Version 2.0 (the "License"). You may not use
 # this file except in compliance with the License. A copy of the License is

--- a/tests/cbmc/proofs/s2n_hmac_update/Makefile.backup
+++ b/tests/cbmc/proofs/s2n_hmac_update/Makefile.backup
@@ -1,0 +1,45 @@
+# Copyright Amazon.com, Inc. or its affiliates. All Rights Reserved.
+#
+# Licensed under the Apache License, Version 2.0 (the "License"). You may not use
+# this file except in compliance with the License. A copy of the License is
+# located at
+#
+#     http://aws.amazon.com/apache2.0/
+#
+# or in the "license" file accompanying this file. This file is distributed on an
+# "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or
+# implied. See the License for the specific language governing permissions and
+# limitations under the License.
+
+# Expected runtime is less than a minute.
+
+CBMCFLAGS +=
+
+PROOF_UID = s2n_hmac_update
+HARNESS_ENTRY = $(PROOF_UID)_harness
+HARNESS_FILE = $(HARNESS_ENTRY).c
+
+PROOF_SOURCES += $(OPENSSL_SOURCE)/bn_override.c
+PROOF_SOURCES += $(OPENSSL_SOURCE)/ec_override.c
+PROOF_SOURCES += $(OPENSSL_SOURCE)/evp_override.c
+PROOF_SOURCES += $(OPENSSL_SOURCE)/md5_override.c
+PROOF_SOURCES += $(OPENSSL_SOURCE)/sha_override.c
+PROOF_SOURCES += $(PROOF_SOURCE)/make_common_datastructures.c
+PROOF_SOURCES += $(PROOF_STUB)/s2n_calculate_stacktrace.c
+PROOF_SOURCES += $(PROOF_STUB)/s2n_is_in_fips_mode.c
+PROOF_SOURCES += $(PROOFDIR)/$(HARNESS_FILE)
+
+PROJECT_SOURCES += $(SRCDIR)/crypto/s2n_hmac.c
+PROJECT_SOURCES += $(SRCDIR)/crypto/s2n_hash.c
+PROJECT_SOURCES += $(SRCDIR)/crypto/s2n_evp.c
+PROJECT_SOURCES += $(SRCDIR)/utils/s2n_result.c
+PROJECT_SOURCES += $(SRCDIR)/utils/s2n_safety.c
+
+# We abstract these functions because manual inspection demonstrates they are unreachable.
+REMOVE_FUNCTION_BODY += __CPROVER_file_local_s2n_hash_c_s2n_evp_hash_digest
+REMOVE_FUNCTION_BODY += __CPROVER_file_local_s2n_hash_c_s2n_hash_digest_size
+REMOVE_FUNCTION_BODY += __CPROVER_file_local_s2n_hash_c_s2n_low_level_hash_digest
+
+UNWINDSET +=
+
+include ../Makefile.common

--- a/tests/cbmc/proofs/s2n_hmac_xor_pad_size/Makefile
+++ b/tests/cbmc/proofs/s2n_hmac_xor_pad_size/Makefile
@@ -1,4 +1,3 @@
-# Copyright Amazon.com, Inc. or its affiliates. All Rights Reserved.
 #
 # Licensed under the Apache License, Version 2.0 (the "License"). You may not use
 # this file except in compliance with the License. A copy of the License is

--- a/tests/cbmc/proofs/s2n_hmac_xor_pad_size/Makefile.backup
+++ b/tests/cbmc/proofs/s2n_hmac_xor_pad_size/Makefile.backup
@@ -1,0 +1,29 @@
+# Copyright Amazon.com, Inc. or its affiliates. All Rights Reserved.
+#
+# Licensed under the Apache License, Version 2.0 (the "License"). You may not use
+# this file except in compliance with the License. A copy of the License is
+# located at
+#
+#     http://aws.amazon.com/apache2.0/
+#
+# or in the "license" file accompanying this file. This file is distributed on an
+# "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or
+# implied. See the License for the specific language governing permissions and
+# limitations under the License.
+
+# Expected runtime is less than 5 seconds.
+
+CBMCFLAGS +=
+
+PROOF_UID = s2n_hmac_xor_pad_size
+HARNESS_ENTRY = $(PROOF_UID)_harness
+HARNESS_FILE = $(HARNESS_ENTRY).c
+
+PROOF_SOURCES += $(PROOFDIR)/$(HARNESS_FILE)
+PROOF_SOURCES += $(PROOF_STUB)/s2n_calculate_stacktrace.c
+
+PROJECT_SOURCES += $(SRCDIR)/crypto/s2n_hmac.c
+
+UNWINDSET +=
+
+include ../Makefile.common

--- a/tests/cbmc/proofs/s2n_is_base64_char/Makefile
+++ b/tests/cbmc/proofs/s2n_is_base64_char/Makefile
@@ -1,4 +1,3 @@
-# Copyright Amazon.com, Inc. or its affiliates. All Rights Reserved.
 #
 # Licensed under the Apache License, Version 2.0 (the "License"). You may not use
 # this file except in compliance with the License. A copy of the License is

--- a/tests/cbmc/proofs/s2n_is_base64_char/Makefile.backup
+++ b/tests/cbmc/proofs/s2n_is_base64_char/Makefile.backup
@@ -1,0 +1,27 @@
+# Copyright Amazon.com, Inc. or its affiliates. All Rights Reserved.
+#
+# Licensed under the Apache License, Version 2.0 (the "License"). You may not use
+# this file except in compliance with the License. A copy of the License is
+# located at
+#
+#     http://aws.amazon.com/apache2.0/
+#
+# or in the "license" file accompanying this file. This file is distributed on an
+# "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or
+# implied. See the License for the specific language governing permissions and
+# limitations under the License.
+
+# Expected runtime is 10 seconds.
+CBMCFLAGS +=
+
+PROOF_UID = s2n_is_base64_char
+HARNESS_ENTRY = $(PROOF_UID)_harness
+HARNESS_FILE = $(HARNESS_ENTRY).c
+
+PROOF_SOURCES += $(PROOFDIR)/$(HARNESS_FILE)
+
+PROJECT_SOURCES += $(SRCDIR)/stuffer/s2n_stuffer_base64.c
+
+UNWINDSET +=
+
+include ../Makefile.common

--- a/tests/cbmc/proofs/s2n_is_hello_retry_handshake/Makefile
+++ b/tests/cbmc/proofs/s2n_is_hello_retry_handshake/Makefile
@@ -1,4 +1,3 @@
-# Copyright Amazon.com, Inc. or its affiliates. All Rights Reserved.
 #
 # Licensed under the Apache License, Version 2.0 (the "License"). You may not use
 # this file except in compliance with the License. A copy of the License is

--- a/tests/cbmc/proofs/s2n_is_hello_retry_handshake/Makefile.backup
+++ b/tests/cbmc/proofs/s2n_is_hello_retry_handshake/Makefile.backup
@@ -1,0 +1,32 @@
+# Copyright Amazon.com, Inc. or its affiliates. All Rights Reserved.
+#
+# Licensed under the Apache License, Version 2.0 (the "License"). You may not use
+# this file except in compliance with the License. A copy of the License is
+# located at
+#
+#     http://aws.amazon.com/apache2.0/
+#
+# or in the "license" file accompanying this file. This file is distributed on an
+# "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or
+# implied. See the License for the specific language governing permissions and
+# limitations under the License.
+
+# Use the default set of CBMC flags.
+CBMCFLAGS +=
+
+PROOF_UID = s2n_is_hello_retry_handshake
+HARNESS_ENTRY = $(PROOF_UID)_harness
+HARNESS_FILE = $(HARNESS_ENTRY).c
+
+PROOF_SOURCES += $(PROOFDIR)/$(HARNESS_FILE)
+PROOF_SOURCES += $(PROOF_STUB)/s2n_calculate_stacktrace.c
+
+PROJECT_SOURCES += $(SRCDIR)/tls/s2n_connection.c
+PROJECT_SOURCES += $(SRCDIR)/tls/s2n_handshake_io.c
+PROJECT_SOURCES += $(SRCDIR)/tls/s2n_handshake_type.c
+PROJECT_SOURCES += $(SRCDIR)/tls/s2n_handshake.c
+PROJECT_SOURCES += $(SRCDIR)/utils/s2n_result.c
+
+UNWINDSET +=
+
+include ../Makefile.common

--- a/tests/cbmc/proofs/s2n_is_hello_retry_message/Makefile
+++ b/tests/cbmc/proofs/s2n_is_hello_retry_message/Makefile
@@ -1,4 +1,3 @@
-# Copyright Amazon.com, Inc. or its affiliates. All Rights Reserved.
 #
 # Licensed under the Apache License, Version 2.0 (the "License"). You may not use
 # this file except in compliance with the License. A copy of the License is

--- a/tests/cbmc/proofs/s2n_is_hello_retry_message/Makefile.backup
+++ b/tests/cbmc/proofs/s2n_is_hello_retry_message/Makefile.backup
@@ -1,0 +1,30 @@
+# Copyright Amazon.com, Inc. or its affiliates. All Rights Reserved.
+#
+# Licensed under the Apache License, Version 2.0 (the "License"). You may not use
+# this file except in compliance with the License. A copy of the License is
+# located at
+#
+#     http://aws.amazon.com/apache2.0/
+#
+# or in the "license" file accompanying this file. This file is distributed on an
+# "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or
+# implied. See the License for the specific language governing permissions and
+# limitations under the License.
+
+# Use the default set of CBMC flags.
+CBMCFLAGS +=
+
+PROOF_UID = s2n_is_hello_retry_message
+HARNESS_ENTRY = $(PROOF_UID)_harness
+HARNESS_FILE = $(HARNESS_ENTRY).c
+
+PROOF_SOURCES += $(PROOFDIR)/$(HARNESS_FILE)
+PROOF_SOURCES += $(PROOF_STUB)/s2n_calculate_stacktrace.c
+
+PROJECT_SOURCES += $(SRCDIR)/tls/s2n_handshake_io.c
+PROJECT_SOURCES += $(SRCDIR)/tls/s2n_handshake.c
+PROJECT_SOURCES += $(SRCDIR)/utils/s2n_result.c
+
+UNWINDSET +=
+
+include ../Makefile.common

--- a/tests/cbmc/proofs/s2n_mem_cleanup/Makefile
+++ b/tests/cbmc/proofs/s2n_mem_cleanup/Makefile
@@ -1,4 +1,3 @@
-# Copyright Amazon.com, Inc. or its affiliates. All Rights Reserved.
 #
 # Licensed under the Apache License, Version 2.0 (the "License"). You may not use
 # this file except in compliance with the License. A copy of the License is

--- a/tests/cbmc/proofs/s2n_mem_cleanup/Makefile.backup
+++ b/tests/cbmc/proofs/s2n_mem_cleanup/Makefile.backup
@@ -1,0 +1,37 @@
+# Copyright Amazon.com, Inc. or its affiliates. All Rights Reserved.
+#
+# Licensed under the Apache License, Version 2.0 (the "License"). You may not use
+# this file except in compliance with the License. A copy of the License is
+# located at
+#
+#     http://aws.amazon.com/apache2.0/
+#
+# or in the "license" file accompanying this file. This file is distributed on an
+# "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or
+# implied. See the License for the specific language governing permissions and
+# limitations under the License.
+#
+# Expected runtime is 10 seconds.
+
+
+CHECKFLAGS +=
+
+PROOF_UID = s2n_mem_cleanup
+HARNESS_ENTRY = $(PROOF_UID)_harness
+HARNESS_FILE = $(HARNESS_ENTRY).c
+
+PROOF_SOURCES += $(PROOFDIR)/$(HARNESS_FILE)
+PROOF_SOURCES += $(PROOF_SOURCE)/cbmc_utils.c
+PROOF_SOURCES += $(PROOF_SOURCE)/make_common_datastructures.c
+PROOF_SOURCES += $(PROOF_STUB)/munlock.c
+PROOF_SOURCES += $(PROOF_STUB)/s2n_calculate_stacktrace.c
+PROOF_SOURCES += $(PROOF_STUB)/sysconf.c
+
+PROJECT_SOURCES += $(SRCDIR)/utils/s2n_blob.c
+PROJECT_SOURCES += $(SRCDIR)/utils/s2n_mem.c
+
+REMOVE_FUNCTION_BODY += __CPROVER_file_local_s2n_mem_c_s2n_mem_cleanup_impl
+
+UNWINDSET +=
+
+include ../Makefile.common

--- a/tests/cbmc/proofs/s2n_mem_init/Makefile
+++ b/tests/cbmc/proofs/s2n_mem_init/Makefile
@@ -1,4 +1,3 @@
-# Copyright Amazon.com, Inc. or its affiliates. All Rights Reserved.
 #
 # Licensed under the Apache License, Version 2.0 (the "License"). You may not use
 # this file except in compliance with the License. A copy of the License is

--- a/tests/cbmc/proofs/s2n_mem_init/Makefile.backup
+++ b/tests/cbmc/proofs/s2n_mem_init/Makefile.backup
@@ -1,0 +1,31 @@
+# Copyright Amazon.com, Inc. or its affiliates. All Rights Reserved.
+#
+# Licensed under the Apache License, Version 2.0 (the "License"). You may not use
+# this file except in compliance with the License. A copy of the License is
+# located at
+#
+#     http://aws.amazon.com/apache2.0/
+#
+# or in the "license" file accompanying this file. This file is distributed on an
+# "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or
+# implied. See the License for the specific language governing permissions and
+# limitations under the License.
+
+CBMCFLAGS +=
+
+PROOF_UID = s2n_mem_init
+HARNESS_ENTRY = $(PROOF_UID)_harness
+HARNESS_FILE = $(HARNESS_ENTRY).c
+
+PROOF_SOURCES += $(PROOFDIR)/$(HARNESS_FILE)
+PROOF_SOURCES += $(PROOF_STUB)/s2n_calculate_stacktrace.c
+PROOF_SOURCES += $(PROOF_STUB)/sysconf.c
+
+PROJECT_SOURCES += $(SRCDIR)/utils/s2n_mem.c
+
+# We abstract this function because manual inspection demonstrates it is unreachable.
+REMOVE_FUNCTION_BODY += __CPROVER_file_local_s2n_mem_c_s2n_mem_cleanup_impl
+
+UNWINDSET +=
+
+include ../Makefile.common

--- a/tests/cbmc/proofs/s2n_mul_overflow_harness/Makefile
+++ b/tests/cbmc/proofs/s2n_mul_overflow_harness/Makefile
@@ -1,4 +1,3 @@
-# Copyright Amazon.com, Inc. or its affiliates. All Rights Reserved.
 #
 # Licensed under the Apache License, Version 2.0 (the "License"). You may not use
 # this file except in compliance with the License. A copy of the License is

--- a/tests/cbmc/proofs/s2n_mul_overflow_harness/Makefile.backup
+++ b/tests/cbmc/proofs/s2n_mul_overflow_harness/Makefile.backup
@@ -1,0 +1,28 @@
+# Copyright Amazon.com, Inc. or its affiliates. All Rights Reserved.
+#
+# Licensed under the Apache License, Version 2.0 (the "License"). You may not use
+# this file except in compliance with the License. A copy of the License is
+# located at
+#
+#     http://aws.amazon.com/apache2.0/
+#
+# or in the "license" file accompanying this file. This file is distributed on an
+# "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or
+# implied. See the License for the specific language governing permissions and
+# limitations under the License.
+
+CBMCFLAGS +=
+
+PROOF_UID = s2n_mul_overflow
+HARNESS_ENTRY = $(PROOF_UID)_harness
+HARNESS_FILE = $(HARNESS_ENTRY).c
+
+PROOF_SOURCES += $(PROOFDIR)/$(HARNESS_FILE)
+PROOF_SOURCES += $(PROOF_SOURCE)/make_common_datastructures.c
+
+PROJECT_SOURCES += $(SRCDIR)/utils/s2n_result.c
+PROJECT_SOURCES += $(SRCDIR)/utils/s2n_safety.c
+
+UNWINDSET +=
+
+include ../Makefile.common

--- a/tests/cbmc/proofs/s2n_pkcs3_to_dh_params/Makefile
+++ b/tests/cbmc/proofs/s2n_pkcs3_to_dh_params/Makefile
@@ -1,4 +1,3 @@
-# Copyright Amazon.com, Inc. or its affiliates. All Rights Reserved.
 #
 # Licensed under the Apache License, Version 2.0 (the "License"). You may not use
 # this file except in compliance with the License. A copy of the License is

--- a/tests/cbmc/proofs/s2n_pkcs3_to_dh_params/Makefile.backup
+++ b/tests/cbmc/proofs/s2n_pkcs3_to_dh_params/Makefile.backup
@@ -1,0 +1,46 @@
+# Copyright Amazon.com, Inc. or its affiliates. All Rights Reserved.
+#
+# Licensed under the Apache License, Version 2.0 (the "License"). You may not use
+# this file except in compliance with the License. A copy of the License is
+# located at
+#
+#     http://aws.amazon.com/apache2.0/
+#
+# or in the "license" file accompanying this file. This file is distributed on an
+# "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or
+# implied. See the License for the specific language governing permissions and
+# limitations under the License.
+
+# Expected runtime is 7 seconds.
+
+MAX_BLOB_SIZE = 10
+DEFINES += -DMAX_BLOB_SIZE=$(MAX_BLOB_SIZE)
+
+CHECKFLAGS +=
+
+PROOF_UID = s2n_pkcs3_to_dh_params
+HARNESS_ENTRY = $(PROOF_UID)_harness
+HARNESS_FILE = $(HARNESS_ENTRY).c
+
+PROOF_SOURCES += $(PROOFDIR)/$(HARNESS_FILE)
+PROOF_SOURCES += $(OPENSSL_SOURCE)/dh_override.c
+PROOF_SOURCES += $(OPENSSL_SOURCE)/bn_override.c
+PROOF_SOURCES += $(PROOF_SOURCE)/cbmc_utils.c
+PROOF_SOURCES += $(PROOF_SOURCE)/make_common_datastructures.c
+PROOF_SOURCES += $(PROOF_STUB)/sysconf.c
+PROOF_SOURCES += $(PROOF_STUB)/s2n_calculate_stacktrace.c
+
+PROJECT_SOURCES += $(SRCDIR)/utils/s2n_blob.c
+PROJECT_SOURCES += $(SRCDIR)/crypto/s2n_dhe.c
+PROJECT_SOURCES += $(SRCDIR)/utils/s2n_ensure.c
+PROJECT_SOURCES += $(SRCDIR)/utils/s2n_mem.c
+PROJECT_SOURCES += $(SRCDIR)/utils/s2n_result.c
+PROJECT_SOURCES += $(SRCDIR)/utils/s2n_safety.c
+PROJECT_SOURCES += $(SRCDIR)/stuffer/s2n_stuffer.c
+
+UNWINDSET +=
+
+# We abstract this function because manual inspection demonstrates it is unreachable.
+REMOVE_FUNCTION_BODY += __CPROVER_file_local_s2n_mem_c_s2n_mem_cleanup_impl
+
+include ../Makefile.common

--- a/tests/cbmc/proofs/s2n_pkcs3_to_dh_params_openssl_1_1_0/Makefile
+++ b/tests/cbmc/proofs/s2n_pkcs3_to_dh_params_openssl_1_1_0/Makefile
@@ -1,4 +1,3 @@
-# Copyright Amazon.com, Inc. or its affiliates. All Rights Reserved.
 #
 # Licensed under the Apache License, Version 2.0 (the "License"). You may not use
 # this file except in compliance with the License. A copy of the License is

--- a/tests/cbmc/proofs/s2n_pkcs3_to_dh_params_openssl_1_1_0/Makefile.backup
+++ b/tests/cbmc/proofs/s2n_pkcs3_to_dh_params_openssl_1_1_0/Makefile.backup
@@ -1,0 +1,47 @@
+# Copyright Amazon.com, Inc. or its affiliates. All Rights Reserved.
+#
+# Licensed under the Apache License, Version 2.0 (the "License"). You may not use
+# this file except in compliance with the License. A copy of the License is
+# located at
+#
+#     http://aws.amazon.com/apache2.0/
+#
+# or in the "license" file accompanying this file. This file is distributed on an
+# "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or
+# implied. See the License for the specific language governing permissions and
+# limitations under the License.
+
+# Expected runtime is 7 seconds.
+
+MAX_BLOB_SIZE = 10
+DEFINES += -DMAX_BLOB_SIZE=$(MAX_BLOB_SIZE)
+DEFINES += -DOPENSSL_VERSION_NUMBER=0x10100000L
+
+CHECKFLAGS +=
+
+PROOF_UID = s2n_pkcs3_to_dh_params_openssl_1_1_0
+HARNESS_ENTRY = $(PROOF_UID)_harness
+HARNESS_FILE = $(HARNESS_ENTRY).c
+
+PROOF_SOURCES += $(PROOFDIR)/$(HARNESS_FILE)
+PROOF_SOURCES += $(OPENSSL_SOURCE)/dh_override.c
+PROOF_SOURCES += $(OPENSSL_SOURCE)/bn_override.c
+PROOF_SOURCES += $(PROOF_SOURCE)/cbmc_utils.c
+PROOF_SOURCES += $(PROOF_SOURCE)/make_common_datastructures.c
+PROOF_SOURCES += $(PROOF_STUB)/sysconf.c
+PROOF_SOURCES += $(PROOF_STUB)/s2n_calculate_stacktrace.c
+
+PROJECT_SOURCES += $(SRCDIR)/utils/s2n_blob.c
+PROJECT_SOURCES += $(SRCDIR)/crypto/s2n_dhe.c
+PROJECT_SOURCES += $(SRCDIR)/utils/s2n_ensure.c
+PROJECT_SOURCES += $(SRCDIR)/utils/s2n_mem.c
+PROJECT_SOURCES += $(SRCDIR)/utils/s2n_result.c
+PROJECT_SOURCES += $(SRCDIR)/utils/s2n_safety.c
+PROJECT_SOURCES += $(SRCDIR)/stuffer/s2n_stuffer.c
+
+UNWINDSET +=
+
+# We abstract this function because manual inspection demonstrates it is unreachable.
+REMOVE_FUNCTION_BODY += __CPROVER_file_local_s2n_mem_c_s2n_mem_cleanup_impl
+
+include ../Makefile.common

--- a/tests/cbmc/proofs/s2n_realloc/Makefile
+++ b/tests/cbmc/proofs/s2n_realloc/Makefile
@@ -1,4 +1,3 @@
-# Copyright Amazon.com, Inc. or its affiliates. All Rights Reserved.
 #
 # Licensed under the Apache License, Version 2.0 (the "License"). You may not use
 # this file except in compliance with the License. A copy of the License is

--- a/tests/cbmc/proofs/s2n_realloc/Makefile.backup
+++ b/tests/cbmc/proofs/s2n_realloc/Makefile.backup
@@ -1,0 +1,42 @@
+# Copyright Amazon.com, Inc. or its affiliates. All Rights Reserved.
+#
+# Licensed under the Apache License, Version 2.0 (the "License"). You may not use
+# this file except in compliance with the License. A copy of the License is
+# located at
+#
+#     http://aws.amazon.com/apache2.0/
+#
+# or in the "license" file accompanying this file. This file is distributed on an
+# "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or
+# implied. See the License for the specific language governing permissions and
+# limitations under the License.
+#
+# Expected runtime is 20 seconds.
+
+CHECKFLAGS +=
+
+PROOF_UID = s2n_realloc
+HARNESS_ENTRY = $(PROOF_UID)_harness
+HARNESS_FILE = $(HARNESS_ENTRY).c
+
+PROOF_SOURCES += $(PROOFDIR)/$(HARNESS_FILE)
+PROOF_SOURCES += $(PROOF_SOURCE)/cbmc_utils.c
+PROOF_SOURCES += $(PROOF_SOURCE)/make_common_datastructures.c
+PROOF_SOURCES += $(PROOF_STUB)/madvise.c
+PROOF_SOURCES += $(PROOF_STUB)/mlock.c
+PROOF_SOURCES += $(PROOF_STUB)/munlock.c
+PROOF_SOURCES += $(PROOF_STUB)/posix_memalign_override.c
+PROOF_SOURCES += $(PROOF_STUB)/s2n_calculate_stacktrace.c
+PROOF_SOURCES += $(PROOF_STUB)/sysconf.c
+
+PROJECT_SOURCES += $(SRCDIR)/utils/s2n_blob.c
+PROJECT_SOURCES += $(SRCDIR)/utils/s2n_ensure.c
+PROJECT_SOURCES += $(SRCDIR)/utils/s2n_mem.c
+PROJECT_SOURCES += $(SRCDIR)/utils/s2n_result.c
+PROJECT_SOURCES += $(SRCDIR)/utils/s2n_safety.c
+
+REMOVE_FUNCTION_BODY += __CPROVER_file_local_s2n_mem_c_s2n_mem_cleanup_impl
+
+UNWINDSET +=
+
+include ../Makefile.common

--- a/tests/cbmc/proofs/s2n_set_add/Makefile
+++ b/tests/cbmc/proofs/s2n_set_add/Makefile
@@ -1,4 +1,3 @@
-# Copyright Amazon.com, Inc. or its affiliates. All Rights Reserved.
 #
 # Licensed under the Apache License, Version 2.0 (the "License"). You may not use
 # this file except in compliance with the License. A copy of the License is

--- a/tests/cbmc/proofs/s2n_set_add/Makefile.backup
+++ b/tests/cbmc/proofs/s2n_set_add/Makefile.backup
@@ -1,0 +1,68 @@
+# Copyright Amazon.com, Inc. or its affiliates. All Rights Reserved.
+#
+# Licensed under the Apache License, Version 2.0 (the "License"). You may not use
+# this file except in compliance with the License. A copy of the License is
+# located at
+#
+#     http://aws.amazon.com/apache2.0/
+#
+# or in the "license" file accompanying this file. This file is distributed on an
+# "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or
+# implied. See the License for the specific language governing permissions and
+# limitations under the License.
+
+# Expected runtime is less than 50 seconds.
+
+MAX_ARRAY_LEN = 10
+DEFINES += -DMAX_ARRAY_LEN=$(MAX_ARRAY_LEN)
+
+MAX_ARRAY_ELEMENT_SIZE = 10
+DEFINES += -DMAX_ARRAY_ELEMENT_SIZE=$(MAX_ARRAY_ELEMENT_SIZE)
+
+BINARY_SEARCH_BOUND = 5
+
+DEFINES += -DMADV_DONTDUMP=1
+
+CBMCFLAGS +=
+
+PROOF_UID = s2n_set_add
+HARNESS_ENTRY = $(PROOF_UID)_harness
+HARNESS_FILE = $(HARNESS_ENTRY).c
+
+PROOF_SOURCES += $(PROOFDIR)/$(HARNESS_FILE)
+PROOF_SOURCES += $(PROOF_SOURCE)/cbmc_utils.c
+PROOF_SOURCES += $(PROOF_SOURCE)/make_common_datastructures.c
+PROOF_SOURCES += $(PROOF_STUB)/madvise.c
+PROOF_SOURCES += $(PROOF_STUB)/memmove_havoc.c
+PROOF_SOURCES += $(PROOF_STUB)/mlock.c
+PROOF_SOURCES += $(PROOF_STUB)/munlock.c
+PROOF_SOURCES += $(PROOF_STUB)/posix_memalign_override.c
+PROOF_SOURCES += $(PROOF_STUB)/s2n_calculate_stacktrace.c
+PROOF_SOURCES += $(PROOF_STUB)/sysconf.c
+
+PROJECT_SOURCES += $(SRCDIR)/utils/s2n_array.c
+PROJECT_SOURCES += $(SRCDIR)/utils/s2n_blob.c
+PROJECT_SOURCES += $(SRCDIR)/utils/s2n_ensure.c
+PROJECT_SOURCES += $(SRCDIR)/utils/s2n_mem.c
+PROJECT_SOURCES += $(SRCDIR)/utils/s2n_result.c
+PROJECT_SOURCES += $(SRCDIR)/utils/s2n_safety.c
+PROJECT_SOURCES += $(SRCDIR)/utils/s2n_set.c
+
+# We abstract this function because manual inspection demonstrates it is unreachable.
+REMOVE_FUNCTION_BODY += s2n_blob_slice
+REMOVE_FUNCTION_BODY += __CPROVER_file_local_s2n_mem_c_s2n_mem_cleanup_impl
+
+UNWINDSET += __CPROVER_file_local_s2n_set_c_s2n_set_binary_search.0:$(call addone,$(BINARY_SEARCH_BOUND))
+UNWINDSET += __CPROVER_file_local_s2n_set_c_s2n_set_binary_search.1:$(call addone,$(BINARY_SEARCH_BOUND))
+UNWINDSET += __CPROVER_file_local_s2n_set_c_s2n_set_binary_search.2:$(call addone,$(BINARY_SEARCH_BOUND))
+UNWINDSET += __CPROVER_file_local_s2n_set_c_s2n_set_binary_search.3:$(call addone,$(BINARY_SEARCH_BOUND))
+UNWINDSET += __CPROVER_file_local_s2n_set_c_s2n_set_binary_search.4:$(call addone,$(BINARY_SEARCH_BOUND))
+UNWINDSET += __CPROVER_file_local_s2n_set_c_s2n_set_binary_search.5:$(call addone,$(BINARY_SEARCH_BOUND))
+UNWINDSET += __CPROVER_file_local_s2n_set_c_s2n_set_binary_search.6:$(call addone,$(BINARY_SEARCH_BOUND))
+UNWINDSET += __CPROVER_file_local_s2n_set_c_s2n_set_binary_search.7:$(call addone,$(BINARY_SEARCH_BOUND))
+UNWINDSET += __CPROVER_file_local_s2n_set_c_s2n_set_binary_search.8:$(call addone,$(BINARY_SEARCH_BOUND))
+UNWINDSET += __CPROVER_file_local_s2n_set_c_s2n_set_binary_search.9:$(call addone,$(BINARY_SEARCH_BOUND))
+UNWINDSET += __CPROVER_file_local_s2n_set_c_s2n_set_binary_search.10:$(call addone,$(BINARY_SEARCH_BOUND))
+UNWINDSET += __CPROVER_file_local_s2n_set_c_s2n_set_binary_search.11:$(call addone,$(BINARY_SEARCH_BOUND))
+
+include ../Makefile.common

--- a/tests/cbmc/proofs/s2n_set_free/Makefile
+++ b/tests/cbmc/proofs/s2n_set_free/Makefile
@@ -1,4 +1,3 @@
-# Copyright Amazon.com, Inc. or its affiliates. All Rights Reserved.
 #
 # Licensed under the Apache License, Version 2.0 (the "License"). You may not use
 # this file except in compliance with the License. A copy of the License is

--- a/tests/cbmc/proofs/s2n_set_free/Makefile.backup
+++ b/tests/cbmc/proofs/s2n_set_free/Makefile.backup
@@ -1,0 +1,41 @@
+# Copyright Amazon.com, Inc. or its affiliates. All Rights Reserved.
+#
+# Licensed under the Apache License, Version 2.0 (the "License"). You may not use
+# this file except in compliance with the License. A copy of the License is
+# located at
+#
+#     http://aws.amazon.com/apache2.0/
+#
+# or in the "license" file accompanying this file. This file is distributed on an
+# "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or
+# implied. See the License for the specific language governing permissions and
+# limitations under the License.
+
+# Expected runtime is less than 10 seconds.
+
+CBMCFLAGS += --memory-leak-check
+
+PROOF_UID = s2n_set_free
+HARNESS_ENTRY = $(PROOF_UID)_harness
+HARNESS_FILE = $(HARNESS_ENTRY).c
+
+PROOF_SOURCES += $(PROOFDIR)/$(HARNESS_FILE)
+PROOF_SOURCES += $(PROOF_SOURCE)/cbmc_utils.c
+PROOF_SOURCES += $(PROOF_SOURCE)/make_common_datastructures.c
+PROOF_SOURCES += $(PROOF_STUB)/munlock.c
+PROOF_SOURCES += $(PROOF_STUB)/s2n_calculate_stacktrace.c
+PROOF_SOURCES += $(PROOF_STUB)/sysconf.c
+
+PROJECT_SOURCES += $(SRCDIR)/utils/s2n_array.c
+PROJECT_SOURCES += $(SRCDIR)/utils/s2n_blob.c
+PROJECT_SOURCES += $(SRCDIR)/utils/s2n_mem.c
+PROJECT_SOURCES += $(SRCDIR)/utils/s2n_result.c
+PROJECT_SOURCES += $(SRCDIR)/utils/s2n_safety.c
+PROJECT_SOURCES += $(SRCDIR)/utils/s2n_set.c
+
+# We abstract this function because manual inspection demonstrates it is unreachable.
+REMOVE_FUNCTION_BODY += __CPROVER_file_local_s2n_mem_c_s2n_mem_cleanup_impl
+
+UNWINDSET +=
+
+include ../Makefile.common

--- a/tests/cbmc/proofs/s2n_set_free_p/Makefile
+++ b/tests/cbmc/proofs/s2n_set_free_p/Makefile
@@ -1,4 +1,3 @@
-# Copyright Amazon.com, Inc. or its affiliates. All Rights Reserved.
 #
 # Licensed under the Apache License, Version 2.0 (the "License"). You may not use
 # this file except in compliance with the License. A copy of the License is

--- a/tests/cbmc/proofs/s2n_set_free_p/Makefile.backup
+++ b/tests/cbmc/proofs/s2n_set_free_p/Makefile.backup
@@ -1,0 +1,41 @@
+# Copyright Amazon.com, Inc. or its affiliates. All Rights Reserved.
+#
+# Licensed under the Apache License, Version 2.0 (the "License"). You may not use
+# this file except in compliance with the License. A copy of the License is
+# located at
+#
+#     http://aws.amazon.com/apache2.0/
+#
+# or in the "license" file accompanying this file. This file is distributed on an
+# "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or
+# implied. See the License for the specific language governing permissions and
+# limitations under the License.
+
+# Expected runtime is less than 10 seconds.
+
+CBMCFLAGS += --memory-leak-check
+
+PROOF_UID = s2n_set_free_p
+HARNESS_ENTRY = $(PROOF_UID)_harness
+HARNESS_FILE = $(HARNESS_ENTRY).c
+
+PROOF_SOURCES += $(PROOFDIR)/$(HARNESS_FILE)
+PROOF_SOURCES += $(PROOF_SOURCE)/cbmc_utils.c
+PROOF_SOURCES += $(PROOF_SOURCE)/make_common_datastructures.c
+PROOF_SOURCES += $(PROOF_STUB)/munlock.c
+PROOF_SOURCES += $(PROOF_STUB)/s2n_calculate_stacktrace.c
+PROOF_SOURCES += $(PROOF_STUB)/sysconf.c
+
+PROJECT_SOURCES += $(SRCDIR)/utils/s2n_array.c
+PROJECT_SOURCES += $(SRCDIR)/utils/s2n_blob.c
+PROJECT_SOURCES += $(SRCDIR)/utils/s2n_mem.c
+PROJECT_SOURCES += $(SRCDIR)/utils/s2n_result.c
+PROJECT_SOURCES += $(SRCDIR)/utils/s2n_safety.c
+PROJECT_SOURCES += $(SRCDIR)/utils/s2n_set.c
+
+# We abstract this function because manual inspection demonstrates it is unreachable.
+REMOVE_FUNCTION_BODY += __CPROVER_file_local_s2n_mem_c_s2n_mem_cleanup_impl
+
+UNWINDSET +=
+
+include ../Makefile.common

--- a/tests/cbmc/proofs/s2n_set_get/Makefile
+++ b/tests/cbmc/proofs/s2n_set_get/Makefile
@@ -1,4 +1,3 @@
-# Copyright Amazon.com, Inc. or its affiliates. All Rights Reserved.
 #
 # Licensed under the Apache License, Version 2.0 (the "License"). You may not use
 # this file except in compliance with the License. A copy of the License is

--- a/tests/cbmc/proofs/s2n_set_get/Makefile.backup
+++ b/tests/cbmc/proofs/s2n_set_get/Makefile.backup
@@ -1,0 +1,40 @@
+# Copyright Amazon.com, Inc. or its affiliates. All Rights Reserved.
+#
+# Licensed under the Apache License, Version 2.0 (the "License"). You may not use
+# this file except in compliance with the License. A copy of the License is
+# located at
+#
+#     http://aws.amazon.com/apache2.0/
+#
+# or in the "license" file accompanying this file. This file is distributed on an
+# "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or
+# implied. See the License for the specific language governing permissions and
+# limitations under the License.
+
+# Expected runtime is less than 10 seconds.
+
+MAX_ARRAY_LEN = 10
+DEFINES += -DMAX_ARRAY_LEN=$(MAX_ARRAY_LEN)
+
+MAX_ARRAY_ELEMENT_SIZE = 10
+DEFINES += -DMAX_ARRAY_ELEMENT_SIZE=$(MAX_ARRAY_ELEMENT_SIZE)
+
+CBMCFLAGS +=
+
+PROOF_UID = s2n_set_get
+HARNESS_ENTRY = $(PROOF_UID)_harness
+HARNESS_FILE = $(HARNESS_ENTRY).c
+
+PROOF_SOURCES += $(PROOFDIR)/$(HARNESS_FILE)
+PROOF_SOURCES += $(PROOF_SOURCE)/make_common_datastructures.c
+PROOF_SOURCES += $(PROOF_STUB)/s2n_calculate_stacktrace.c
+
+PROJECT_SOURCES += $(SRCDIR)/utils/s2n_array.c
+PROJECT_SOURCES += $(SRCDIR)/utils/s2n_blob.c
+PROJECT_SOURCES += $(SRCDIR)/utils/s2n_result.c
+PROJECT_SOURCES += $(SRCDIR)/utils/s2n_safety.c
+PROJECT_SOURCES += $(SRCDIR)/utils/s2n_set.c
+
+UNWINDSET +=
+
+include ../Makefile.common

--- a/tests/cbmc/proofs/s2n_set_len/Makefile
+++ b/tests/cbmc/proofs/s2n_set_len/Makefile
@@ -1,4 +1,3 @@
-# Copyright Amazon.com, Inc. or its affiliates. All Rights Reserved.
 #
 # Licensed under the Apache License, Version 2.0 (the "License"). You may not use
 # this file except in compliance with the License. A copy of the License is

--- a/tests/cbmc/proofs/s2n_set_len/Makefile.backup
+++ b/tests/cbmc/proofs/s2n_set_len/Makefile.backup
@@ -1,0 +1,40 @@
+# Copyright Amazon.com, Inc. or its affiliates. All Rights Reserved.
+#
+# Licensed under the Apache License, Version 2.0 (the "License"). You may not use
+# this file except in compliance with the License. A copy of the License is
+# located at
+#
+#     http://aws.amazon.com/apache2.0/
+#
+# or in the "license" file accompanying this file. This file is distributed on an
+# "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or
+# implied. See the License for the specific language governing permissions and
+# limitations under the License.
+
+# Expected runtime is less than 30 seconds.
+
+MAX_ARRAY_LEN = 100
+DEFINES += -DMAX_ARRAY_LEN=$(MAX_ARRAY_LEN)
+
+MAX_ARRAY_ELEMENT_SIZE = 100
+DEFINES += -DMAX_ARRAY_ELEMENT_SIZE=$(MAX_ARRAY_ELEMENT_SIZE)
+
+CBMCFLAGS +=
+
+PROOF_UID = s2n_set_len
+HARNESS_ENTRY = $(PROOF_UID)_harness
+HARNESS_FILE = $(HARNESS_ENTRY).c
+
+PROOF_SOURCES += $(PROOFDIR)/$(HARNESS_FILE)
+PROOF_SOURCES += $(PROOF_SOURCE)/make_common_datastructures.c
+PROOF_SOURCES += $(PROOF_STUB)/s2n_calculate_stacktrace.c
+
+PROJECT_SOURCES += $(SRCDIR)/utils/s2n_array.c
+PROJECT_SOURCES += $(SRCDIR)/utils/s2n_blob.c
+PROJECT_SOURCES += $(SRCDIR)/utils/s2n_result.c
+PROJECT_SOURCES += $(SRCDIR)/utils/s2n_safety.c
+PROJECT_SOURCES += $(SRCDIR)/utils/s2n_set.c
+
+UNWINDSET +=
+
+include ../Makefile.common

--- a/tests/cbmc/proofs/s2n_set_new/Makefile
+++ b/tests/cbmc/proofs/s2n_set_new/Makefile
@@ -1,4 +1,3 @@
-# Copyright Amazon.com, Inc. or its affiliates. All Rights Reserved.
 #
 # Licensed under the Apache License, Version 2.0 (the "License"). You may not use
 # this file except in compliance with the License. A copy of the License is

--- a/tests/cbmc/proofs/s2n_set_new/Makefile.backup
+++ b/tests/cbmc/proofs/s2n_set_new/Makefile.backup
@@ -1,0 +1,50 @@
+# Copyright Amazon.com, Inc. or its affiliates. All Rights Reserved.
+#
+# Licensed under the Apache License, Version 2.0 (the "License"). You may not use
+# this file except in compliance with the License. A copy of the License is
+# located at
+#
+#     http://aws.amazon.com/apache2.0/
+#
+# or in the "license" file accompanying this file. This file is distributed on an
+# "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or
+# implied. See the License for the specific language governing permissions and
+# limitations under the License.
+
+# Expected runtime is less than 20 seconds.
+
+DEFINES += -DMADV_DONTDUMP=1
+
+CBMCFLAGS +=
+
+PROOF_UID = s2n_set_new
+HARNESS_ENTRY = $(PROOF_UID)_harness
+HARNESS_FILE = $(HARNESS_ENTRY).c
+
+PROOF_SOURCES += $(PROOFDIR)/$(HARNESS_FILE)
+PROOF_SOURCES += $(PROOF_SOURCE)/cbmc_utils.c
+PROOF_SOURCES += $(PROOF_SOURCE)/make_common_datastructures.c
+PROOF_SOURCES += $(PROOF_STUB)/madvise.c
+PROOF_SOURCES += $(PROOF_STUB)/memset_havoc.c
+PROOF_SOURCES += $(PROOF_STUB)/mlock.c
+PROOF_SOURCES += $(PROOF_STUB)/munlock.c
+PROOF_SOURCES += $(PROOF_STUB)/posix_memalign_override.c
+PROOF_SOURCES += $(PROOF_STUB)/s2n_calculate_stacktrace.c
+PROOF_SOURCES += $(PROOF_STUB)/sysconf.c
+
+PROJECT_SOURCES += $(SRCDIR)/utils/s2n_result.c
+PROJECT_SOURCES += $(SRCDIR)/utils/s2n_array.c
+PROJECT_SOURCES += $(SRCDIR)/utils/s2n_blob.c
+PROJECT_SOURCES += $(SRCDIR)/utils/s2n_ensure.c
+PROJECT_SOURCES += $(SRCDIR)/utils/s2n_mem.c
+PROJECT_SOURCES += $(SRCDIR)/utils/s2n_safety.c
+PROJECT_SOURCES += $(SRCDIR)/utils/s2n_set.c
+
+# We abstract these functions because manual inspection demonstrates they are unreachable.
+REMOVE_FUNCTION_BODY += s2n_blob_slice
+REMOVE_FUNCTION_BODY += s2n_ensure_memcpy_trace
+REMOVE_FUNCTION_BODY += __CPROVER_file_local_s2n_mem_c_s2n_mem_cleanup_impl
+
+UNWINDSET +=
+
+include ../Makefile.common

--- a/tests/cbmc/proofs/s2n_set_remove/Makefile
+++ b/tests/cbmc/proofs/s2n_set_remove/Makefile
@@ -1,4 +1,3 @@
-# Copyright Amazon.com, Inc. or its affiliates. All Rights Reserved.
 #
 # Licensed under the Apache License, Version 2.0 (the "License"). You may not use
 # this file except in compliance with the License. A copy of the License is

--- a/tests/cbmc/proofs/s2n_set_remove/Makefile.backup
+++ b/tests/cbmc/proofs/s2n_set_remove/Makefile.backup
@@ -1,0 +1,45 @@
+# Copyright Amazon.com, Inc. or its affiliates. All Rights Reserved.
+#
+# Licensed under the Apache License, Version 2.0 (the "License"). You may not use
+# this file except in compliance with the License. A copy of the License is
+# located at
+#
+#     http://aws.amazon.com/apache2.0/
+#
+# or in the "license" file accompanying this file. This file is distributed on an
+# "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or
+# implied. See the License for the specific language governing permissions and
+# limitations under the License.
+
+# Expected runtime is less than 10 seconds.
+
+MAX_ARRAY_LEN = 10
+DEFINES += -DMAX_ARRAY_LEN=$(MAX_ARRAY_LEN)
+
+MAX_ARRAY_ELEMENT_SIZE = 10
+DEFINES += -DMAX_ARRAY_ELEMENT_SIZE=$(MAX_ARRAY_ELEMENT_SIZE)
+
+CBMCFLAGS +=
+
+PROOF_UID = s2n_set_remove
+HARNESS_ENTRY = $(PROOF_UID)_harness
+HARNESS_FILE = $(HARNESS_ENTRY).c
+
+PROOF_SOURCES += $(PROOFDIR)/$(HARNESS_FILE)
+PROOF_SOURCES += $(PROOF_SOURCE)/cbmc_utils.c
+PROOF_SOURCES += $(PROOF_SOURCE)/make_common_datastructures.c
+PROOF_SOURCES += $(PROOF_STUB)/memmove_havoc.c
+PROOF_SOURCES += $(PROOF_STUB)/mlock.c
+PROOF_SOURCES += $(PROOF_STUB)/munlock.c
+PROOF_SOURCES += $(PROOF_STUB)/s2n_calculate_stacktrace.c
+PROOF_SOURCES += $(PROOF_STUB)/sysconf.c
+
+PROJECT_SOURCES += $(SRCDIR)/utils/s2n_array.c
+PROJECT_SOURCES += $(SRCDIR)/utils/s2n_blob.c
+PROJECT_SOURCES += $(SRCDIR)/utils/s2n_result.c
+PROJECT_SOURCES += $(SRCDIR)/utils/s2n_safety.c
+PROJECT_SOURCES += $(SRCDIR)/utils/s2n_set.c
+
+UNWINDSET +=
+
+include ../Makefile.common

--- a/tests/cbmc/proofs/s2n_socket_is_ipv6/Makefile
+++ b/tests/cbmc/proofs/s2n_socket_is_ipv6/Makefile
@@ -1,5 +1,3 @@
-# Copyright Amazon.com, Inc. or its affiliates. All Rights Reserved.
-# SPDX-License-Identifier: Apache-2.0
 
 # This should be a unique identifier for this proof, and will appear on the
 # Litani dashboard. It can be human-readable and contain spaces if you wish.

--- a/tests/cbmc/proofs/s2n_socket_is_ipv6/Makefile.backup
+++ b/tests/cbmc/proofs/s2n_socket_is_ipv6/Makefile.backup
@@ -1,0 +1,22 @@
+# Copyright Amazon.com, Inc. or its affiliates. All Rights Reserved.
+# SPDX-License-Identifier: Apache-2.0
+
+# This should be a unique identifier for this proof, and will appear on the
+# Litani dashboard. It can be human-readable and contain spaces if you wish.
+PROOF_UID = s2n_socket_is_ipv6
+HARNESS_ENTRY = $(PROOF_UID)_harness
+HARNESS_FILE = $(HARNESS_ENTRY).c
+
+DEFINES +=
+INCLUDES +=
+
+REMOVE_FUNCTION_BODY +=
+UNWINDSET +=
+
+PROOF_SOURCES += $(PROOFDIR)/$(HARNESS_FILE)
+PROOF_SOURCES += $(PROOF_STUB)/getpeername.c
+PROOF_SOURCES += $(PROOF_STUB)/s2n_calculate_stacktrace.c
+
+PROJECT_SOURCES += $(SRCDIR)/utils/s2n_socket.c
+
+include ../Makefile.common

--- a/tests/cbmc/proofs/s2n_socket_quickack/Makefile
+++ b/tests/cbmc/proofs/s2n_socket_quickack/Makefile
@@ -1,5 +1,3 @@
-# Copyright Amazon.com, Inc. or its affiliates. All Rights Reserved.
-# SPDX-License-Identifier: Apache-2.0
 
 # This should be a unique identifier for this proof, and will appear on the
 # Litani dashboard. It can be human-readable and contain spaces if you wish.

--- a/tests/cbmc/proofs/s2n_socket_quickack/Makefile.backup
+++ b/tests/cbmc/proofs/s2n_socket_quickack/Makefile.backup
@@ -1,0 +1,23 @@
+# Copyright Amazon.com, Inc. or its affiliates. All Rights Reserved.
+# SPDX-License-Identifier: Apache-2.0
+
+# This should be a unique identifier for this proof, and will appear on the
+# Litani dashboard. It can be human-readable and contain spaces if you wish.
+PROOF_UID = s2n_socket_quickack
+HARNESS_ENTRY = $(PROOF_UID)_harness
+HARNESS_FILE = $(HARNESS_ENTRY).c
+
+DEFINES += -DTCP_QUICKACK=1
+INCLUDES +=
+
+REMOVE_FUNCTION_BODY +=
+UNWINDSET +=
+
+PROOF_SOURCES += $(PROOFDIR)/$(HARNESS_FILE)
+PROOF_SOURCES += $(PROOF_SOURCE)/make_common_datastructures.c
+PROOF_SOURCES += $(PROOF_STUB)/setsockopt.c
+PROOF_SOURCES += $(PROOF_STUB)/s2n_calculate_stacktrace.c
+
+PROJECT_SOURCES += $(SRCDIR)/utils/s2n_socket.c
+
+include ../Makefile.common

--- a/tests/cbmc/proofs/s2n_socket_read/Makefile
+++ b/tests/cbmc/proofs/s2n_socket_read/Makefile
@@ -1,5 +1,3 @@
-# Copyright Amazon.com, Inc. or its affiliates. All Rights Reserved.
-# SPDX-License-Identifier: Apache-2.0
 
 # This should be a unique identifier for this proof, and will appear on the
 # Litani dashboard. It can be human-readable and contain spaces if you wish.

--- a/tests/cbmc/proofs/s2n_socket_read/Makefile.backup
+++ b/tests/cbmc/proofs/s2n_socket_read/Makefile.backup
@@ -1,0 +1,24 @@
+# Copyright Amazon.com, Inc. or its affiliates. All Rights Reserved.
+# SPDX-License-Identifier: Apache-2.0
+
+# This should be a unique identifier for this proof, and will appear on the
+# Litani dashboard. It can be human-readable and contain spaces if you wish.
+PROOF_UID = s2n_socket_read
+HARNESS_ENTRY = $(PROOF_UID)_harness
+HARNESS_FILE = $(HARNESS_ENTRY).c
+
+DEFINES +=
+INCLUDES +=
+
+REMOVE_FUNCTION_BODY +=
+UNWINDSET +=
+
+PROOF_SOURCES += $(PROOFDIR)/$(HARNESS_FILE)
+PROOF_SOURCES += $(PROOF_SOURCE)/make_common_datastructures.c
+PROOF_SOURCES += $(PROOF_STUB)/getpeername.c
+PROOF_SOURCES += $(PROOF_STUB)/read.c
+PROOF_SOURCES += $(PROOF_STUB)/s2n_calculate_stacktrace.c
+
+PROJECT_SOURCES += $(SRCDIR)/utils/s2n_socket.c
+
+include ../Makefile.common

--- a/tests/cbmc/proofs/s2n_socket_read_restore/Makefile
+++ b/tests/cbmc/proofs/s2n_socket_read_restore/Makefile
@@ -1,5 +1,3 @@
-# Copyright Amazon.com, Inc. or its affiliates. All Rights Reserved.
-# SPDX-License-Identifier: Apache-2.0
 
 # This should be a unique identifier for this proof, and will appear on the
 # Litani dashboard. It can be human-readable and contain spaces if you wish.

--- a/tests/cbmc/proofs/s2n_socket_read_restore/Makefile.backup
+++ b/tests/cbmc/proofs/s2n_socket_read_restore/Makefile.backup
@@ -1,0 +1,23 @@
+# Copyright Amazon.com, Inc. or its affiliates. All Rights Reserved.
+# SPDX-License-Identifier: Apache-2.0
+
+# This should be a unique identifier for this proof, and will appear on the
+# Litani dashboard. It can be human-readable and contain spaces if you wish.
+PROOF_UID = s2n_socket_read_restore
+HARNESS_ENTRY = $(PROOF_UID)_harness
+HARNESS_FILE = $(HARNESS_ENTRY).c
+
+DEFINES +=
+INCLUDES +=
+
+REMOVE_FUNCTION_BODY +=
+UNWINDSET +=
+
+PROOF_SOURCES += $(PROOFDIR)/$(HARNESS_FILE)
+PROOF_SOURCES += $(PROOF_SOURCE)/make_common_datastructures.c
+PROOF_SOURCES += $(PROOF_STUB)/setsockopt.c
+PROOF_SOURCES += $(PROOF_STUB)/s2n_calculate_stacktrace.c
+
+PROJECT_SOURCES += $(SRCDIR)/utils/s2n_socket.c
+
+include ../Makefile.common

--- a/tests/cbmc/proofs/s2n_socket_read_snapshot/Makefile
+++ b/tests/cbmc/proofs/s2n_socket_read_snapshot/Makefile
@@ -1,5 +1,3 @@
-# Copyright Amazon.com, Inc. or its affiliates. All Rights Reserved.
-# SPDX-License-Identifier: Apache-2.0
 
 # This should be a unique identifier for this proof, and will appear on the
 # Litani dashboard. It can be human-readable and contain spaces if you wish.

--- a/tests/cbmc/proofs/s2n_socket_read_snapshot/Makefile.backup
+++ b/tests/cbmc/proofs/s2n_socket_read_snapshot/Makefile.backup
@@ -1,0 +1,23 @@
+# Copyright Amazon.com, Inc. or its affiliates. All Rights Reserved.
+# SPDX-License-Identifier: Apache-2.0
+
+# This should be a unique identifier for this proof, and will appear on the
+# Litani dashboard. It can be human-readable and contain spaces if you wish.
+PROOF_UID = s2n_socket_read_snapshot
+HARNESS_ENTRY = $(PROOF_UID)_harness
+HARNESS_FILE = $(HARNESS_ENTRY).c
+
+DEFINES +=
+INCLUDES +=
+
+REMOVE_FUNCTION_BODY +=
+UNWINDSET +=
+
+PROOF_SOURCES += $(PROOFDIR)/$(HARNESS_FILE)
+PROOF_SOURCES += $(PROOF_SOURCE)/make_common_datastructures.c
+PROOF_SOURCES += $(PROOF_STUB)/getsockopt.c
+PROOF_SOURCES += $(PROOF_STUB)/s2n_calculate_stacktrace.c
+
+PROJECT_SOURCES += $(SRCDIR)/utils/s2n_socket.c
+
+include ../Makefile.common

--- a/tests/cbmc/proofs/s2n_socket_set_read_size/Makefile
+++ b/tests/cbmc/proofs/s2n_socket_set_read_size/Makefile
@@ -1,5 +1,3 @@
-# Copyright Amazon.com, Inc. or its affiliates. All Rights Reserved.
-# SPDX-License-Identifier: Apache-2.0
 
 # This should be a unique identifier for this proof, and will appear on the
 # Litani dashboard. It can be human-readable and contain spaces if you wish.

--- a/tests/cbmc/proofs/s2n_socket_set_read_size/Makefile.backup
+++ b/tests/cbmc/proofs/s2n_socket_set_read_size/Makefile.backup
@@ -1,0 +1,23 @@
+# Copyright Amazon.com, Inc. or its affiliates. All Rights Reserved.
+# SPDX-License-Identifier: Apache-2.0
+
+# This should be a unique identifier for this proof, and will appear on the
+# Litani dashboard. It can be human-readable and contain spaces if you wish.
+PROOF_UID = s2n_socket_set_read_size
+HARNESS_ENTRY = $(PROOF_UID)_harness
+HARNESS_FILE = $(HARNESS_ENTRY).c
+
+DEFINES +=
+INCLUDES +=
+
+REMOVE_FUNCTION_BODY +=
+UNWINDSET +=
+
+PROOF_SOURCES += $(PROOFDIR)/$(HARNESS_FILE)
+PROOF_SOURCES += $(PROOF_SOURCE)/make_common_datastructures.c
+PROOF_SOURCES += $(PROOF_STUB)/setsockopt.c
+PROOF_SOURCES += $(PROOF_STUB)/s2n_calculate_stacktrace.c
+
+PROJECT_SOURCES += $(SRCDIR)/utils/s2n_socket.c
+
+include ../Makefile.common

--- a/tests/cbmc/proofs/s2n_socket_was_corked/Makefile
+++ b/tests/cbmc/proofs/s2n_socket_was_corked/Makefile
@@ -1,5 +1,3 @@
-# Copyright Amazon.com, Inc. or its affiliates. All Rights Reserved.
-# SPDX-License-Identifier: Apache-2.0
 
 # This should be a unique identifier for this proof, and will appear on the
 # Litani dashboard. It can be human-readable and contain spaces if you wish.

--- a/tests/cbmc/proofs/s2n_socket_was_corked/Makefile.backup
+++ b/tests/cbmc/proofs/s2n_socket_was_corked/Makefile.backup
@@ -1,0 +1,22 @@
+# Copyright Amazon.com, Inc. or its affiliates. All Rights Reserved.
+# SPDX-License-Identifier: Apache-2.0
+
+# This should be a unique identifier for this proof, and will appear on the
+# Litani dashboard. It can be human-readable and contain spaces if you wish.
+PROOF_UID = s2n_socket_was_corked
+HARNESS_ENTRY = $(PROOF_UID)_harness
+HARNESS_FILE = $(HARNESS_ENTRY).c
+
+DEFINES +=
+INCLUDES +=
+
+REMOVE_FUNCTION_BODY +=
+UNWINDSET +=
+
+PROOF_SOURCES += $(PROOFDIR)/$(HARNESS_FILE)
+PROOF_SOURCES += $(PROOF_SOURCE)/make_common_datastructures.c
+PROOF_SOURCES += $(PROOF_STUB)/s2n_calculate_stacktrace.c
+
+PROJECT_SOURCES += $(SRCDIR)/utils/s2n_socket.c
+
+include ../Makefile.common

--- a/tests/cbmc/proofs/s2n_socket_write/Makefile
+++ b/tests/cbmc/proofs/s2n_socket_write/Makefile
@@ -1,5 +1,3 @@
-# Copyright Amazon.com, Inc. or its affiliates. All Rights Reserved.
-# SPDX-License-Identifier: Apache-2.0
 
 # This should be a unique identifier for this proof, and will appear on the
 # Litani dashboard. It can be human-readable and contain spaces if you wish.

--- a/tests/cbmc/proofs/s2n_socket_write/Makefile.backup
+++ b/tests/cbmc/proofs/s2n_socket_write/Makefile.backup
@@ -1,0 +1,24 @@
+# Copyright Amazon.com, Inc. or its affiliates. All Rights Reserved.
+# SPDX-License-Identifier: Apache-2.0
+
+# This should be a unique identifier for this proof, and will appear on the
+# Litani dashboard. It can be human-readable and contain spaces if you wish.
+PROOF_UID = s2n_socket_write
+HARNESS_ENTRY = $(PROOF_UID)_harness
+HARNESS_FILE = $(HARNESS_ENTRY).c
+
+DEFINES +=
+INCLUDES +=
+
+REMOVE_FUNCTION_BODY +=
+UNWINDSET +=
+
+PROOF_SOURCES += $(PROOFDIR)/$(HARNESS_FILE)
+PROOF_SOURCES += $(PROOF_SOURCE)/make_common_datastructures.c
+PROOF_SOURCES += $(PROOF_STUB)/s2n_calculate_stacktrace.c
+PROOF_SOURCES += $(PROOF_STUB)/write.c
+
+PROJECT_SOURCES += $(SRCDIR)/utils/s2n_result.c
+PROJECT_SOURCES += $(SRCDIR)/utils/s2n_socket.c
+
+include ../Makefile.common

--- a/tests/cbmc/proofs/s2n_socket_write_cork/Makefile
+++ b/tests/cbmc/proofs/s2n_socket_write_cork/Makefile
@@ -1,5 +1,3 @@
-# Copyright Amazon.com, Inc. or its affiliates. All Rights Reserved.
-# SPDX-License-Identifier: Apache-2.0
 
 # This should be a unique identifier for this proof, and will appear on the
 # Litani dashboard. It can be human-readable and contain spaces if you wish.

--- a/tests/cbmc/proofs/s2n_socket_write_cork/Makefile.backup
+++ b/tests/cbmc/proofs/s2n_socket_write_cork/Makefile.backup
@@ -1,0 +1,24 @@
+# Copyright Amazon.com, Inc. or its affiliates. All Rights Reserved.
+# SPDX-License-Identifier: Apache-2.0
+
+# This should be a unique identifier for this proof, and will appear on the
+# Litani dashboard. It can be human-readable and contain spaces if you wish.
+PROOF_UID = s2n_socket_write_cork
+HARNESS_ENTRY = $(PROOF_UID)_harness
+HARNESS_FILE = $(HARNESS_ENTRY).c
+
+DEFINES +=
+INCLUDES +=
+
+REMOVE_FUNCTION_BODY +=
+UNWINDSET +=
+
+PROOF_SOURCES += $(PROOFDIR)/$(HARNESS_FILE)
+PROOF_SOURCES += $(PROOF_SOURCE)/make_common_datastructures.c
+PROOF_SOURCES += $(PROOF_STUB)/setsockopt.c
+PROOF_SOURCES += $(PROOF_STUB)/s2n_calculate_stacktrace.c
+
+PROJECT_SOURCES += $(SRCDIR)/utils/s2n_result.c
+PROJECT_SOURCES += $(SRCDIR)/utils/s2n_socket.c
+
+include ../Makefile.common

--- a/tests/cbmc/proofs/s2n_socket_write_restore/Makefile
+++ b/tests/cbmc/proofs/s2n_socket_write_restore/Makefile
@@ -1,5 +1,3 @@
-# Copyright Amazon.com, Inc. or its affiliates. All Rights Reserved.
-# SPDX-License-Identifier: Apache-2.0
 
 # This should be a unique identifier for this proof, and will appear on the
 # Litani dashboard. It can be human-readable and contain spaces if you wish.

--- a/tests/cbmc/proofs/s2n_socket_write_restore/Makefile.backup
+++ b/tests/cbmc/proofs/s2n_socket_write_restore/Makefile.backup
@@ -1,0 +1,24 @@
+# Copyright Amazon.com, Inc. or its affiliates. All Rights Reserved.
+# SPDX-License-Identifier: Apache-2.0
+
+# This should be a unique identifier for this proof, and will appear on the
+# Litani dashboard. It can be human-readable and contain spaces if you wish.
+PROOF_UID = s2n_socket_write_restore
+HARNESS_ENTRY = $(PROOF_UID)_harness
+HARNESS_FILE = $(HARNESS_ENTRY).c
+
+DEFINES +=
+INCLUDES +=
+
+REMOVE_FUNCTION_BODY +=
+UNWINDSET +=
+
+PROOF_SOURCES += $(PROOFDIR)/$(HARNESS_FILE)
+PROOF_SOURCES += $(PROOF_SOURCE)/make_common_datastructures.c
+PROOF_SOURCES += $(PROOF_STUB)/setsockopt.c
+PROOF_SOURCES += $(PROOF_STUB)/s2n_calculate_stacktrace.c
+
+PROJECT_SOURCES += $(SRCDIR)/utils/s2n_result.c
+PROJECT_SOURCES += $(SRCDIR)/utils/s2n_socket.c
+
+include ../Makefile.common

--- a/tests/cbmc/proofs/s2n_socket_write_snapshot/Makefile
+++ b/tests/cbmc/proofs/s2n_socket_write_snapshot/Makefile
@@ -1,5 +1,3 @@
-# Copyright Amazon.com, Inc. or its affiliates. All Rights Reserved.
-# SPDX-License-Identifier: Apache-2.0
 
 # This should be a unique identifier for this proof, and will appear on the
 # Litani dashboard. It can be human-readable and contain spaces if you wish.

--- a/tests/cbmc/proofs/s2n_socket_write_snapshot/Makefile.backup
+++ b/tests/cbmc/proofs/s2n_socket_write_snapshot/Makefile.backup
@@ -1,0 +1,24 @@
+# Copyright Amazon.com, Inc. or its affiliates. All Rights Reserved.
+# SPDX-License-Identifier: Apache-2.0
+
+# This should be a unique identifier for this proof, and will appear on the
+# Litani dashboard. It can be human-readable and contain spaces if you wish.
+PROOF_UID = s2n_socket_write_snapshot
+HARNESS_ENTRY = $(PROOF_UID)_harness
+HARNESS_FILE = $(HARNESS_ENTRY).c
+
+DEFINES +=
+INCLUDES +=
+
+REMOVE_FUNCTION_BODY +=
+UNWINDSET +=
+
+PROOF_SOURCES += $(PROOFDIR)/$(HARNESS_FILE)
+PROOF_SOURCES += $(PROOF_SOURCE)/make_common_datastructures.c
+PROOF_SOURCES += $(PROOF_STUB)/getsockopt.c
+PROOF_SOURCES += $(PROOF_STUB)/s2n_calculate_stacktrace.c
+
+PROJECT_SOURCES += $(SRCDIR)/utils/s2n_result.c
+PROJECT_SOURCES += $(SRCDIR)/utils/s2n_socket.c
+
+include ../Makefile.common

--- a/tests/cbmc/proofs/s2n_socket_write_uncork/Makefile
+++ b/tests/cbmc/proofs/s2n_socket_write_uncork/Makefile
@@ -1,5 +1,3 @@
-# Copyright Amazon.com, Inc. or its affiliates. All Rights Reserved.
-# SPDX-License-Identifier: Apache-2.0
 
 # This should be a unique identifier for this proof, and will appear on the
 # Litani dashboard. It can be human-readable and contain spaces if you wish.

--- a/tests/cbmc/proofs/s2n_socket_write_uncork/Makefile.backup
+++ b/tests/cbmc/proofs/s2n_socket_write_uncork/Makefile.backup
@@ -1,0 +1,24 @@
+# Copyright Amazon.com, Inc. or its affiliates. All Rights Reserved.
+# SPDX-License-Identifier: Apache-2.0
+
+# This should be a unique identifier for this proof, and will appear on the
+# Litani dashboard. It can be human-readable and contain spaces if you wish.
+PROOF_UID = s2n_socket_write_uncork
+HARNESS_ENTRY = $(PROOF_UID)_harness
+HARNESS_FILE = $(HARNESS_ENTRY).c
+
+DEFINES +=
+INCLUDES +=
+
+REMOVE_FUNCTION_BODY +=
+UNWINDSET +=
+
+PROOF_SOURCES += $(PROOFDIR)/$(HARNESS_FILE)
+PROOF_SOURCES += $(PROOF_SOURCE)/make_common_datastructures.c
+PROOF_SOURCES += $(PROOF_STUB)/setsockopt.c
+PROOF_SOURCES += $(PROOF_STUB)/s2n_calculate_stacktrace.c
+
+PROJECT_SOURCES += $(SRCDIR)/utils/s2n_result.c
+PROJECT_SOURCES += $(SRCDIR)/utils/s2n_socket.c
+
+include ../Makefile.common

--- a/tests/cbmc/proofs/s2n_stuffer_alloc/Makefile.backup
+++ b/tests/cbmc/proofs/s2n_stuffer_alloc/Makefile.backup
@@ -1,0 +1,47 @@
+# Copyright 2020 Amazon.com, Inc. or its affiliates. All Rights Reserved.
+#
+# Licensed under the Apache License, Version 2.0 (the "License"). You may not use
+# this file except in compliance with the License. A copy of the License is
+# located at
+#
+#     http://aws.amazon.com/apache2.0/
+#
+# or in the "license" file accompanying this file. This file is distributed on an
+# "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or
+# implied. See the License for the specific language governing permissions and
+# limitations under the License.
+
+# Expected runtime is 15 seconds.
+
+CHECKFLAGS +=
+
+DEFINES += -DMADV_DONTDUMP=1
+
+PROOF_UID = s2n_stuffer_alloc
+HARNESS_ENTRY = $(PROOF_UID)_harness
+HARNESS_FILE = $(HARNESS_ENTRY).c
+
+PROOF_SOURCES += $(PROOFDIR)/$(HARNESS_FILE)
+PROOF_SOURCES += $(PROOF_SOURCE)/cbmc_utils.c
+PROOF_SOURCES += $(PROOF_SOURCE)/make_common_datastructures.c
+PROOF_SOURCES += $(PROOF_STUB)/mlock.c
+PROOF_SOURCES += $(PROOF_STUB)/munlock.c
+PROOF_SOURCES += $(PROOF_STUB)/posix_memalign_override.c
+PROOF_SOURCES += $(PROOF_STUB)/s2n_calculate_stacktrace.c
+PROOF_SOURCES += $(PROOF_STUB)/sysconf.c
+
+PROJECT_SOURCES += $(SRCDIR)/stuffer/s2n_stuffer.c
+PROJECT_SOURCES += $(SRCDIR)/utils/s2n_blob.c
+PROJECT_SOURCES += $(SRCDIR)/utils/s2n_ensure.c
+PROJECT_SOURCES += $(SRCDIR)/utils/s2n_mem.c
+PROJECT_SOURCES += $(SRCDIR)/utils/s2n_result.c
+PROJECT_SOURCES += $(SRCDIR)/utils/s2n_safety.c
+
+# We abstract these functions because manual inspection demonstrates they are unreachable.
+REMOVE_FUNCTION_BODY += __CPROVER_file_local_s2n_mem_c_s2n_mem_cleanup_impl
+REMOVE_FUNCTION_BODY += s2n_blob_slice
+REMOVE_FUNCTION_BODY += s2n_ensure_memcpy_trace
+
+UNWINDSET +=
+
+include ../Makefile.common

--- a/tests/cbmc/proofs/s2n_stuffer_alloc_ro_from_fd/Makefile
+++ b/tests/cbmc/proofs/s2n_stuffer_alloc_ro_from_fd/Makefile
@@ -1,4 +1,3 @@
-# Copyright Amazon.com, Inc. or its affiliates. All Rights Reserved.
 #
 # Licensed under the Apache License, Version 2.0 (the "License"). You may not use
 # this file except in compliance with the License. A copy of the License is

--- a/tests/cbmc/proofs/s2n_stuffer_alloc_ro_from_fd/Makefile.backup
+++ b/tests/cbmc/proofs/s2n_stuffer_alloc_ro_from_fd/Makefile.backup
@@ -1,0 +1,36 @@
+# Copyright Amazon.com, Inc. or its affiliates. All Rights Reserved.
+#
+# Licensed under the Apache License, Version 2.0 (the "License"). You may not use
+# this file except in compliance with the License. A copy of the License is
+# located at
+#
+#     http://aws.amazon.com/apache2.0/
+#
+# or in the "license" file accompanying this file. This file is distributed on an
+# "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or
+# implied. See the License for the specific language governing permissions and
+# limitations under the License.
+
+# Expected runtime is 10 seconds.
+
+CBMCFLAGS +=
+
+PROOF_UID = s2n_stuffer_alloc_ro_from_fd
+HARNESS_ENTRY = $(PROOF_UID)_harness
+HARNESS_FILE = $(HARNESS_ENTRY).c
+
+PROOF_SOURCES += $(PROOFDIR)/$(HARNESS_FILE)
+PROOF_SOURCES += $(PROOF_SOURCE)/cbmc_utils.c
+PROOF_SOURCES += $(PROOF_SOURCE)/make_common_datastructures.c
+PROOF_SOURCES += $(PROOF_STUB)/fstat.c
+PROOF_SOURCES += $(PROOF_STUB)/mmap.c
+PROOF_SOURCES += $(PROOF_STUB)/s2n_calculate_stacktrace.c
+
+PROJECT_SOURCES += $(SRCDIR)/stuffer/s2n_stuffer.c
+PROJECT_SOURCES += $(SRCDIR)/stuffer/s2n_stuffer_file.c
+PROJECT_SOURCES += $(SRCDIR)/utils/s2n_blob.c
+PROJECT_SOURCES += $(SRCDIR)/utils/s2n_result.c
+
+UNWINDSET +=
+
+include ../Makefile.common

--- a/tests/cbmc/proofs/s2n_stuffer_alloc_ro_from_file/Makefile
+++ b/tests/cbmc/proofs/s2n_stuffer_alloc_ro_from_file/Makefile
@@ -1,4 +1,3 @@
-# Copyright Amazon.com, Inc. or its affiliates. All Rights Reserved.
 #
 # Licensed under the Apache License, Version 2.0 (the "License"). You may not use
 # this file except in compliance with the License. A copy of the License is

--- a/tests/cbmc/proofs/s2n_stuffer_alloc_ro_from_file/Makefile.backup
+++ b/tests/cbmc/proofs/s2n_stuffer_alloc_ro_from_file/Makefile.backup
@@ -1,0 +1,40 @@
+# Copyright Amazon.com, Inc. or its affiliates. All Rights Reserved.
+#
+# Licensed under the Apache License, Version 2.0 (the "License"). You may not use
+# this file except in compliance with the License. A copy of the License is
+# located at
+#
+#     http://aws.amazon.com/apache2.0/
+#
+# or in the "license" file accompanying this file. This file is distributed on an
+# "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or
+# implied. See the License for the specific language governing permissions and
+# limitations under the License.
+
+# Enough to get full coverage with 10 seconds of runtime.
+MAX_STRING_LEN = 10
+DEFINES += -DMAX_STRING_LEN=$(MAX_STRING_LEN)
+
+CBMCFLAGS +=
+
+PROOF_UID = s2n_stuffer_alloc_ro_from_file
+HARNESS_ENTRY = $(PROOF_UID)_harness
+HARNESS_FILE = $(HARNESS_ENTRY).c
+
+PROOF_SOURCES += $(PROOFDIR)/$(HARNESS_FILE)
+PROOF_SOURCES += $(PROOF_SOURCE)/cbmc_utils.c
+PROOF_SOURCES += $(PROOF_SOURCE)/make_common_datastructures.c
+PROOF_SOURCES += $(PROOF_STUB)/close.c
+PROOF_SOURCES += $(PROOF_STUB)/fstat.c
+PROOF_SOURCES += $(PROOF_STUB)/mmap.c
+PROOF_SOURCES += $(PROOF_STUB)/open.c
+PROOF_SOURCES += $(PROOF_STUB)/s2n_calculate_stacktrace.c
+
+PROJECT_SOURCES += $(SRCDIR)/stuffer/s2n_stuffer.c
+PROJECT_SOURCES += $(SRCDIR)/stuffer/s2n_stuffer_file.c
+PROJECT_SOURCES += $(SRCDIR)/utils/s2n_blob.c
+PROJECT_SOURCES += $(SRCDIR)/utils/s2n_result.c
+
+UNWINDSET += s2n_stuffer_alloc_ro_from_file.9:3
+
+include ../Makefile.common

--- a/tests/cbmc/proofs/s2n_stuffer_alloc_ro_from_string/Makefile.backup
+++ b/tests/cbmc/proofs/s2n_stuffer_alloc_ro_from_string/Makefile.backup
@@ -1,0 +1,46 @@
+# Copyright 2020 Amazon.com, Inc. or its affiliates. All Rights Reserved.
+#
+# Licensed under the Apache License, Version 2.0 (the "License"). You may not use
+# this file except in compliance with the License. A copy of the License is
+# located at
+#
+#     http://aws.amazon.com/apache2.0/
+#
+# or in the "license" file accompanying this file. This file is distributed on an
+# "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or
+# implied. See the License for the specific language governing permissions and
+# limitations under the License.
+
+# Enough to get full coverage with 20 seconds of runtime.
+MAX_STRING_LEN = 100
+DEFINES += -DMAX_STRING_LEN=$(MAX_STRING_LEN)
+
+CHECKFLAGS +=
+
+PROOF_UID = s2n_stuffer_alloc_ro_from_string
+HARNESS_ENTRY = $(PROOF_UID)_harness
+HARNESS_FILE = $(HARNESS_ENTRY).c
+
+PROOF_SOURCES += $(PROOFDIR)/$(HARNESS_FILE)
+PROOF_SOURCES += $(PROOF_SOURCE)/cbmc_utils.c
+PROOF_SOURCES += $(PROOF_SOURCE)/make_common_datastructures.c
+
+PROJECT_SOURCES += $(SRCDIR)/stuffer/s2n_stuffer.c
+PROJECT_SOURCES += $(SRCDIR)/stuffer/s2n_stuffer_text.c
+PROJECT_SOURCES += $(SRCDIR)/utils/s2n_blob.c
+PROJECT_SOURCES += $(SRCDIR)/utils/s2n_ensure.c
+PROJECT_SOURCES += $(SRCDIR)/utils/s2n_mem.c
+PROJECT_SOURCES += $(SRCDIR)/utils/s2n_result.c
+PROJECT_SOURCES += $(SRCDIR)/utils/s2n_safety.c
+
+# We abstract these functions because manual inspection demonstrates they are unreachable.
+REMOVE_FUNCTION_BODY += __CPROVER_file_local_s2n_mem_c_s2n_mem_cleanup_impl
+REMOVE_FUNCTION_BODY += s2n_blob_slice
+REMOVE_FUNCTION_BODY += s2n_free
+REMOVE_FUNCTION_BODY += s2n_stuffer_resize
+REMOVE_FUNCTION_BODY += s2n_add_overflow
+REMOVE_FUNCTION_BODY += s2n_blob_zero
+
+UNWINDSET += strlen.0:$(call addone,$(MAX_STRING_LEN))
+
+include ../Makefile.common

--- a/tests/cbmc/proofs/s2n_stuffer_certificate_from_pem/Makefile.backup
+++ b/tests/cbmc/proofs/s2n_stuffer_certificate_from_pem/Makefile.backup
@@ -1,0 +1,55 @@
+# Copyright 2020 Amazon.com, Inc. or its affiliates. All Rights Reserved.
+#
+# Licensed under the Apache License, Version 2.0 (the "License"). You may not use
+# this file except in compliance with the License. A copy of the License is
+# located at
+#
+#     http://aws.amazon.com/apache2.0/
+#
+# or in the "license" file accompanying this file. This file is distributed on an
+# "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or
+# implied. See the License for the specific language governing permissions and
+# limitations under the License.
+
+# Enough to get full coverage with 7 minutes of runtime.
+MAX_BLOB_SIZE = 10
+DEFINES += -DMAX_BLOB_SIZE=$(MAX_BLOB_SIZE)
+
+CHECKFLAGS +=
+
+PROOF_UID = s2n_stuffer_certificate_from_pem
+HARNESS_ENTRY = $(PROOF_UID)_harness
+HARNESS_FILE = $(HARNESS_ENTRY).c
+
+PROOF_SOURCES += $(PROOFDIR)/$(HARNESS_FILE)
+PROOF_SOURCES += $(PROOF_SOURCE)/cbmc_utils.c
+PROOF_SOURCES += $(PROOF_SOURCE)/make_common_datastructures.c
+PROOF_SOURCES += $(PROOF_STUB)/s2n_calculate_stacktrace.c
+PROOF_SOURCES += $(PROOF_STUB)/sysconf.c
+PROOF_SOURCES += $(PROOF_STUB)/s2n_stuffer_read_expected_str.c
+PROOF_SOURCES += $(PROOF_STUB)/s2n_stuffer_skip_expected_char.c
+PROOF_SOURCES += $(PROOF_STUB)/s2n_stuffer_skip_to_char.c
+PROOF_SOURCES += $(PROOF_STUB)/s2n_stuffer_skip_whitespace.c
+PROOF_SOURCES += $(PROOF_STUB)/s2n_stuffer_read_base64.c
+PROJECT_SOURCES += $(SRCDIR)/stuffer/s2n_stuffer.c
+PROJECT_SOURCES += $(SRCDIR)/stuffer/s2n_stuffer_pem.c
+PROJECT_SOURCES += $(SRCDIR)/stuffer/s2n_stuffer_text.c
+PROJECT_SOURCES += $(SRCDIR)/stuffer/s2n_stuffer_base64.c
+PROJECT_SOURCES += $(SRCDIR)/stuffer/s2n_stuffer_network_order.c
+PROJECT_SOURCES += $(SRCDIR)/utils/s2n_blob.c
+PROJECT_SOURCES += $(SRCDIR)/utils/s2n_ensure.c
+PROJECT_SOURCES += $(SRCDIR)/utils/s2n_mem.c
+PROJECT_SOURCES += $(SRCDIR)/utils/s2n_result.c
+PROJECT_SOURCES += $(SRCDIR)/utils/s2n_safety.c
+
+# We abstract this function because manual inspection demonstrates it is unreachable.
+REMOVE_FUNCTION_BODY += s2n_stuffer_resize
+REMOVE_FUNCTION_BODY += s2n_stuffer_rewrite
+REMOVE_FUNCTION_BODY += s2n_add_overflow
+
+UNWINDSET += strlen.0:5 # size of S2N_PEM_PKCS1_RSA_PRIVATE_KEY
+UNWINDSET += strncmp.0:5 # size of S2N_PEM_END_TOKEN
+UNWINDSET += __CPROVER_file_local_s2n_stuffer_pem_c_s2n_stuffer_pem_read_contents.11:$(call addone,$(MAX_BLOB_SIZE))
+UNWINDSET += s2n_stuffer_skip_to_char.3:$(call addone,$(MAX_BLOB_SIZE))
+
+include ../Makefile.common

--- a/tests/cbmc/proofs/s2n_stuffer_copy/Makefile
+++ b/tests/cbmc/proofs/s2n_stuffer_copy/Makefile
@@ -1,4 +1,3 @@
-# Copyright Amazon.com, Inc. or its affiliates. All Rights Reserved.
 #
 # Licensed under the Apache License, Version 2.0 (the "License"). You may not use
 # this file except in compliance with the License. A copy of the License is

--- a/tests/cbmc/proofs/s2n_stuffer_copy/Makefile.backup
+++ b/tests/cbmc/proofs/s2n_stuffer_copy/Makefile.backup
@@ -1,0 +1,45 @@
+# Copyright Amazon.com, Inc. or its affiliates. All Rights Reserved.
+#
+# Licensed under the Apache License, Version 2.0 (the "License"). You may not use
+# this file except in compliance with the License. A copy of the License is
+# located at
+#
+#     http://aws.amazon.com/apache2.0/
+#
+# or in the "license" file accompanying this file. This file is distributed on an
+# "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or
+# implied. See the License for the specific language governing permissions and
+# limitations under the License.
+
+# Expected runtime is less than 1 minute.
+
+CHECKFLAGS +=
+
+PROOF_UID = s2n_stuffer_copy
+HARNESS_ENTRY = $(PROOF_UID)_harness
+HARNESS_FILE = $(HARNESS_ENTRY).c
+
+PROOF_SOURCES += $(PROOFDIR)/$(HARNESS_FILE)
+PROOF_SOURCES += $(PROOF_SOURCE)/cbmc_utils.c
+PROOF_SOURCES += $(PROOF_SOURCE)/make_common_datastructures.c
+PROOF_SOURCES += $(PROOF_STUB)/mlock.c
+PROOF_SOURCES += $(PROOF_STUB)/munlock.c
+PROOF_SOURCES += $(PROOF_STUB)/posix_memalign_override.c
+PROOF_SOURCES += $(PROOF_STUB)/s2n_calculate_stacktrace.c
+PROOF_SOURCES += $(PROOF_STUB)/sysconf.c
+
+PROJECT_SOURCES += $(SRCDIR)/stuffer/s2n_stuffer.c
+PROJECT_SOURCES += $(SRCDIR)/utils/s2n_blob.c
+PROJECT_SOURCES += $(SRCDIR)/utils/s2n_ensure.c
+PROJECT_SOURCES += $(SRCDIR)/utils/s2n_mem.c
+PROJECT_SOURCES += $(SRCDIR)/utils/s2n_result.c
+PROJECT_SOURCES += $(SRCDIR)/utils/s2n_safety.c
+
+# We abstract this function because manual inspection demonstrates it is unreachable.
+REMOVE_FUNCTION_BODY += __CPROVER_file_local_s2n_mem_c_s2n_mem_cleanup_impl
+REMOVE_FUNCTION_BODY += s2n_blob_slice
+REMOVE_FUNCTION_BODY += s2n_stuffer_wipe
+
+UNWINDSET +=
+
+include ../Makefile.common

--- a/tests/cbmc/proofs/s2n_stuffer_dhparams_from_pem/Makefile.backup
+++ b/tests/cbmc/proofs/s2n_stuffer_dhparams_from_pem/Makefile.backup
@@ -1,0 +1,55 @@
+# Copyright 2020 Amazon.com, Inc. or its affiliates. All Rights Reserved.
+#
+# Licensed under the Apache License, Version 2.0 (the "License"). You may not use
+# this file except in compliance with the License. A copy of the License is
+# located at
+#
+#     http://aws.amazon.com/apache2.0/
+#
+# or in the "license" file accompanying this file. This file is distributed on an
+# "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or
+# implied. See the License for the specific language governing permissions and
+# limitations under the License.
+
+# Enough to get full coverage with 7 minutes of runtime.
+MAX_BLOB_SIZE = 10
+DEFINES += -DMAX_BLOB_SIZE=$(MAX_BLOB_SIZE)
+
+CHECKFLAGS +=
+
+PROOF_UID = s2n_stuffer_dhparams_from_pem
+HARNESS_ENTRY = $(PROOF_UID)_harness
+HARNESS_FILE = $(HARNESS_ENTRY).c
+
+PROOF_SOURCES += $(PROOFDIR)/$(HARNESS_FILE)
+PROOF_SOURCES += $(PROOF_SOURCE)/cbmc_utils.c
+PROOF_SOURCES += $(PROOF_SOURCE)/make_common_datastructures.c
+PROOF_SOURCES += $(PROOF_STUB)/s2n_calculate_stacktrace.c
+PROOF_SOURCES += $(PROOF_STUB)/sysconf.c
+PROOF_SOURCES += $(PROOF_STUB)/s2n_stuffer_read_expected_str.c
+PROOF_SOURCES += $(PROOF_STUB)/s2n_stuffer_skip_expected_char.c
+PROOF_SOURCES += $(PROOF_STUB)/s2n_stuffer_skip_to_char.c
+PROOF_SOURCES += $(PROOF_STUB)/s2n_stuffer_skip_whitespace.c
+PROOF_SOURCES += $(PROOF_STUB)/s2n_stuffer_read_base64.c
+PROJECT_SOURCES += $(SRCDIR)/stuffer/s2n_stuffer.c
+PROJECT_SOURCES += $(SRCDIR)/stuffer/s2n_stuffer_pem.c
+PROJECT_SOURCES += $(SRCDIR)/stuffer/s2n_stuffer_text.c
+PROJECT_SOURCES += $(SRCDIR)/stuffer/s2n_stuffer_base64.c
+PROJECT_SOURCES += $(SRCDIR)/stuffer/s2n_stuffer_network_order.c
+PROJECT_SOURCES += $(SRCDIR)/utils/s2n_blob.c
+PROJECT_SOURCES += $(SRCDIR)/utils/s2n_ensure.c
+PROJECT_SOURCES += $(SRCDIR)/utils/s2n_mem.c
+PROJECT_SOURCES += $(SRCDIR)/utils/s2n_result.c
+PROJECT_SOURCES += $(SRCDIR)/utils/s2n_safety.c
+
+# We abstract these functions because manual inspection demonstrates they are unreachable.
+REMOVE_FUNCTION_BODY += s2n_stuffer_resize
+REMOVE_FUNCTION_BODY += s2n_stuffer_rewrite
+REMOVE_FUNCTION_BODY += s2n_add_overflow
+
+UNWINDSET += strlen.0:5 # size of S2N_PEM_PKCS1_RSA_PRIVATE_KEY
+UNWINDSET += strncmp.0:5 # size of S2N_PEM_END_TOKEN
+UNWINDSET += __CPROVER_file_local_s2n_stuffer_pem_c_s2n_stuffer_pem_read_contents.11:$(call addone,$(MAX_BLOB_SIZE))
+UNWINDSET += s2n_stuffer_skip_to_char.3:$(call addone,$(MAX_BLOB_SIZE))
+
+include ../Makefile.common

--- a/tests/cbmc/proofs/s2n_stuffer_erase_and_read/Makefile
+++ b/tests/cbmc/proofs/s2n_stuffer_erase_and_read/Makefile
@@ -1,4 +1,3 @@
-# Copyright Amazon.com, Inc. or its affiliates. All Rights Reserved.
 #
 # Licensed under the Apache License, Version 2.0 (the "License"). You may not use
 # this file except in compliance with the License. A copy of the License is

--- a/tests/cbmc/proofs/s2n_stuffer_erase_and_read/Makefile.backup
+++ b/tests/cbmc/proofs/s2n_stuffer_erase_and_read/Makefile.backup
@@ -1,0 +1,35 @@
+# Copyright Amazon.com, Inc. or its affiliates. All Rights Reserved.
+#
+# Licensed under the Apache License, Version 2.0 (the "License"). You may not use
+# this file except in compliance with the License. A copy of the License is
+# located at
+#
+#     http://aws.amazon.com/apache2.0/
+#
+# or in the "license" file accompanying this file. This file is distributed on an
+# "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or
+# implied. See the License for the specific language governing permissions and
+# limitations under the License.
+
+###########
+#Use the default set of CBMC flags
+CHECKFLAGS +=
+
+PROOF_UID = s2n_stuffer_erase_and_read
+HARNESS_ENTRY = $(PROOF_UID)_harness
+HARNESS_FILE = $(HARNESS_ENTRY).c
+
+PROOF_SOURCES += $(PROOFDIR)/$(HARNESS_FILE)
+PROOF_SOURCES += $(PROOF_SOURCE)/cbmc_utils.c
+PROOF_SOURCES += $(PROOF_SOURCE)/make_common_datastructures.c
+
+PROJECT_SOURCES += $(SRCDIR)/stuffer/s2n_stuffer.c
+PROJECT_SOURCES += $(SRCDIR)/utils/s2n_blob.c
+PROJECT_SOURCES += $(SRCDIR)/utils/s2n_ensure.c
+PROJECT_SOURCES += $(SRCDIR)/utils/s2n_result.c
+
+#No loops to unwind
+UNWINDSET +=
+###########
+
+include ../Makefile.common

--- a/tests/cbmc/proofs/s2n_stuffer_erase_and_read_bytes/Makefile.backup
+++ b/tests/cbmc/proofs/s2n_stuffer_erase_and_read_bytes/Makefile.backup
@@ -1,0 +1,35 @@
+# Copyright 2020 Amazon.com, Inc. or its affiliates. All Rights Reserved.
+#
+# Licensed under the Apache License, Version 2.0 (the "License"). You may not use
+# this file except in compliance with the License. A copy of the License is
+# located at
+#
+#     http://aws.amazon.com/apache2.0/
+#
+# or in the "license" file accompanying this file. This file is distributed on an
+# "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or
+# implied. See the License for the specific language governing permissions and
+# limitations under the License.
+
+###########
+#Use the default set of CBMC flags
+CHECKFLAGS +=
+
+PROOF_UID = s2n_stuffer_erase_and_read_bytes
+HARNESS_ENTRY = $(PROOF_UID)_harness
+HARNESS_FILE = $(HARNESS_ENTRY).c
+
+PROOF_SOURCES += $(PROOFDIR)/$(HARNESS_FILE)
+PROOF_SOURCES += $(PROOF_SOURCE)/cbmc_utils.c
+PROOF_SOURCES += $(PROOF_SOURCE)/make_common_datastructures.c
+
+PROJECT_SOURCES += $(SRCDIR)/stuffer/s2n_stuffer.c
+PROJECT_SOURCES += $(SRCDIR)/utils/s2n_blob.c
+PROJECT_SOURCES += $(SRCDIR)/utils/s2n_ensure.c
+PROJECT_SOURCES += $(SRCDIR)/utils/s2n_result.c
+
+#No loops to unwind
+UNWINDSET +=
+###########
+
+include ../Makefile.common

--- a/tests/cbmc/proofs/s2n_stuffer_extract_blob/Makefile
+++ b/tests/cbmc/proofs/s2n_stuffer_extract_blob/Makefile
@@ -1,4 +1,3 @@
-# Copyright Amazon.com, Inc. or its affiliates. All Rights Reserved.
 #
 # Licensed under the Apache License, Version 2.0 (the "License"). You may not use
 # this file except in compliance with the License. A copy of the License is

--- a/tests/cbmc/proofs/s2n_stuffer_extract_blob/Makefile.backup
+++ b/tests/cbmc/proofs/s2n_stuffer_extract_blob/Makefile.backup
@@ -1,0 +1,41 @@
+# Copyright Amazon.com, Inc. or its affiliates. All Rights Reserved.
+#
+# Licensed under the Apache License, Version 2.0 (the "License"). You may not use
+# this file except in compliance with the License. A copy of the License is
+# located at
+#
+#     http://aws.amazon.com/apache2.0/
+#
+# or in the "license" file accompanying this file. This file is distributed on an
+# "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or
+# implied. See the License for the specific language governing permissions and
+# limitations under the License.
+
+# Expected runtime is 20 seconds.
+CBMCFLAGS +=
+
+PROOF_UID = s2n_stuffer_extract_blob
+HARNESS_ENTRY = $(PROOF_UID)_harness
+HARNESS_FILE = $(HARNESS_ENTRY).c
+
+PROOF_SOURCES += $(PROOFDIR)/$(HARNESS_FILE)
+PROOF_SOURCES += $(PROOF_SOURCE)/cbmc_utils.c
+PROOF_SOURCES += $(PROOF_SOURCE)/make_common_datastructures.c
+PROOF_SOURCES += $(PROOF_STUB)/s2n_calculate_stacktrace.c
+PROOF_SOURCES += $(PROOF_STUB)/munlock.c
+PROOF_SOURCES += $(PROOF_STUB)/sysconf.c
+
+PROJECT_SOURCES += $(SRCDIR)/error/s2n_errno.c
+PROJECT_SOURCES += $(SRCDIR)/stuffer/s2n_stuffer.c
+PROJECT_SOURCES += $(SRCDIR)/utils/s2n_blob.c
+PROJECT_SOURCES += $(SRCDIR)/utils/s2n_ensure.c
+PROJECT_SOURCES += $(SRCDIR)/utils/s2n_mem.c
+PROJECT_SOURCES += $(SRCDIR)/utils/s2n_result.c
+PROJECT_SOURCES += $(SRCDIR)/utils/s2n_safety.c
+
+# We abstract this function because manual inspection demonstrates it is unreachable.
+REMOVE_FUNCTION_BODY +=  s2n_blob_slice
+
+UNWINDSET +=
+
+include ../Makefile.common

--- a/tests/cbmc/proofs/s2n_stuffer_free/Makefile
+++ b/tests/cbmc/proofs/s2n_stuffer_free/Makefile
@@ -1,4 +1,3 @@
-# Copyright Amazon.com, Inc. or its affiliates. All Rights Reserved.
 #
 # Licensed under the Apache License, Version 2.0 (the "License"). You may not use
 # this file except in compliance with the License. A copy of the License is

--- a/tests/cbmc/proofs/s2n_stuffer_free/Makefile.backup
+++ b/tests/cbmc/proofs/s2n_stuffer_free/Makefile.backup
@@ -1,0 +1,40 @@
+# Copyright Amazon.com, Inc. or its affiliates. All Rights Reserved.
+#
+# Licensed under the Apache License, Version 2.0 (the "License"). You may not use
+# this file except in compliance with the License. A copy of the License is
+# located at
+#
+#     http://aws.amazon.com/apache2.0/
+#
+# or in the "license" file accompanying this file. This file is distributed on an
+# "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or
+# implied. See the License for the specific language governing permissions and
+# limitations under the License.
+
+# Expected runtime is 10 seconds.
+
+CHECKFLAGS += --memory-leak-check
+
+PROOF_UID = s2n_stuffer_free
+HARNESS_ENTRY = $(PROOF_UID)_harness
+HARNESS_FILE = $(HARNESS_ENTRY).c
+
+PROOF_SOURCES += $(PROOFDIR)/$(HARNESS_FILE)
+PROOF_SOURCES += $(PROOF_SOURCE)/cbmc_utils.c
+PROOF_SOURCES += $(PROOF_SOURCE)/make_common_datastructures.c
+PROOF_SOURCES += $(PROOF_STUB)/munlock.c
+PROOF_SOURCES += $(PROOF_STUB)/s2n_calculate_stacktrace.c
+PROOF_SOURCES += $(PROOF_STUB)/sysconf.c
+
+PROJECT_SOURCES += $(SRCDIR)/stuffer/s2n_stuffer.c
+PROJECT_SOURCES += $(SRCDIR)/utils/s2n_mem.c
+PROJECT_SOURCES += $(SRCDIR)/utils/s2n_blob.c
+PROJECT_SOURCES += $(SRCDIR)/utils/s2n_ensure.c
+PROJECT_SOURCES += $(SRCDIR)/utils/s2n_result.c
+
+# We abstract this function because manual inspection demonstrates it is unreachable.
+REMOVE_FUNCTION_BODY += __CPROVER_file_local_s2n_mem_c_s2n_mem_cleanup_impl
+
+UNWINDSET +=
+
+include ../Makefile.common

--- a/tests/cbmc/proofs/s2n_stuffer_growable_alloc/Makefile.backup
+++ b/tests/cbmc/proofs/s2n_stuffer_growable_alloc/Makefile.backup
@@ -1,0 +1,45 @@
+# Copyright 2020 Amazon.com, Inc. or its affiliates. All Rights Reserved.
+#
+# Licensed under the Apache License, Version 2.0 (the "License"). You may not use
+# this file except in compliance with the License. A copy of the License is
+# located at
+#
+#     http://aws.amazon.com/apache2.0/
+#
+# or in the "license" file accompanying this file. This file is distributed on an
+# "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or
+# implied. See the License for the specific language governing permissions and
+# limitations under the License.
+
+# Expected runtime is 20 seconds.
+
+CHECKFLAGS +=
+
+PROOF_UID = s2n_stuffer_growable_alloc
+HARNESS_ENTRY = $(PROOF_UID)_harness
+HARNESS_FILE = $(HARNESS_ENTRY).c
+
+PROOF_SOURCES += $(PROOFDIR)/$(HARNESS_FILE)
+PROOF_SOURCES += $(PROOF_SOURCE)/cbmc_utils.c
+PROOF_SOURCES += $(PROOF_SOURCE)/make_common_datastructures.c
+PROOF_SOURCES += $(PROOF_STUB)/mlock.c
+PROOF_SOURCES += $(PROOF_STUB)/munlock.c
+PROOF_SOURCES += $(PROOF_STUB)/posix_memalign_override.c
+PROOF_SOURCES += $(PROOF_STUB)/s2n_calculate_stacktrace.c
+PROOF_SOURCES += $(PROOF_STUB)/sysconf.c
+
+PROJECT_SOURCES += $(SRCDIR)/stuffer/s2n_stuffer.c
+PROJECT_SOURCES += $(SRCDIR)/utils/s2n_blob.c
+PROJECT_SOURCES += $(SRCDIR)/utils/s2n_ensure.c
+PROJECT_SOURCES += $(SRCDIR)/utils/s2n_mem.c
+PROJECT_SOURCES += $(SRCDIR)/utils/s2n_result.c
+PROJECT_SOURCES += $(SRCDIR)/utils/s2n_safety.c
+
+# We abstract these functions because manual inspection demonstrates they are unreachable.
+REMOVE_FUNCTION_BODY += __CPROVER_file_local_s2n_mem_c_s2n_mem_cleanup_impl
+REMOVE_FUNCTION_BODY += s2n_blob_slice
+REMOVE_FUNCTION_BODY += s2n_ensure_memcpy_trace
+
+UNWINDSET +=
+
+include ../Makefile.common

--- a/tests/cbmc/proofs/s2n_stuffer_init/Makefile
+++ b/tests/cbmc/proofs/s2n_stuffer_init/Makefile
@@ -1,4 +1,3 @@
-# Copyright Amazon.com, Inc. or its affiliates. All Rights Reserved.
 #
 # Licensed under the Apache License, Version 2.0 (the "License"). You may not use
 # this file except in compliance with the License. A copy of the License is

--- a/tests/cbmc/proofs/s2n_stuffer_init/Makefile.backup
+++ b/tests/cbmc/proofs/s2n_stuffer_init/Makefile.backup
@@ -1,0 +1,34 @@
+# Copyright Amazon.com, Inc. or its affiliates. All Rights Reserved.
+#
+# Licensed under the Apache License, Version 2.0 (the "License"). You may not use
+# this file except in compliance with the License. A copy of the License is
+# located at
+#
+#     http://aws.amazon.com/apache2.0/
+#
+# or in the "license" file accompanying this file. This file is distributed on an
+# "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or
+# implied. See the License for the specific language governing permissions and
+# limitations under the License.
+
+###########
+#Use the default set of CBMC flags
+CHECKFLAGS +=
+
+PROOF_UID = s2n_stuffer_init
+HARNESS_ENTRY = $(PROOF_UID)_harness
+HARNESS_FILE = $(HARNESS_ENTRY).c
+
+PROOF_SOURCES += $(PROOFDIR)/$(HARNESS_FILE)
+PROOF_SOURCES += $(PROOF_SOURCE)/make_common_datastructures.c
+
+PROJECT_SOURCES += $(SRCDIR)/stuffer/s2n_stuffer.c
+PROJECT_SOURCES += $(SRCDIR)/utils/s2n_blob.c
+PROJECT_SOURCES += $(SRCDIR)/utils/s2n_ensure.c
+PROJECT_SOURCES += $(SRCDIR)/utils/s2n_result.c
+
+#No loops to unwind
+UNWINDSET +=
+###########
+
+include ../Makefile.common

--- a/tests/cbmc/proofs/s2n_stuffer_is_consumed/Makefile
+++ b/tests/cbmc/proofs/s2n_stuffer_is_consumed/Makefile
@@ -1,4 +1,3 @@
-# Copyright Amazon.com, Inc. or its affiliates. All Rights Reserved.
 #
 # Licensed under the Apache License, Version 2.0 (the "License"). You may not use
 # this file except in compliance with the License. A copy of the License is

--- a/tests/cbmc/proofs/s2n_stuffer_is_consumed/Makefile.backup
+++ b/tests/cbmc/proofs/s2n_stuffer_is_consumed/Makefile.backup
@@ -1,0 +1,36 @@
+# Copyright Amazon.com, Inc. or its affiliates. All Rights Reserved.
+#
+# Licensed under the Apache License, Version 2.0 (the "License"). You may not use
+# this file except in compliance with the License. A copy of the License is
+# located at
+#
+#     http://aws.amazon.com/apache2.0/
+#
+# or in the "license" file accompanying this file. This file is distributed on an
+# "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or
+# implied. See the License for the specific language governing permissions and
+# limitations under the License.
+
+# Expected runtime is 10 seconds.
+
+CBMCFLAGS +=
+
+PROOF_UID = s2n_stuffer_is_consumed
+HARNESS_ENTRY = $(PROOF_UID)_harness
+HARNESS_FILE = $(HARNESS_ENTRY).c
+
+PROOF_SOURCES += $(PROOFDIR)/$(HARNESS_FILE)
+PROOF_SOURCES += $(PROOF_SOURCE)/cbmc_utils.c
+PROOF_SOURCES += $(PROOF_SOURCE)/make_common_datastructures.c
+
+PROJECT_SOURCES += $(SRCDIR)/error/s2n_errno.c
+PROJECT_SOURCES += $(SRCDIR)/stuffer/s2n_stuffer.c
+PROJECT_SOURCES += $(SRCDIR)/utils/s2n_blob.c
+PROJECT_SOURCES += $(SRCDIR)/utils/s2n_result.c
+
+# We abstract this function because manual inspection demonstrates it is unreachable.
+REMOVE_FUNCTION_BODY += s2n_calculate_stacktrace
+
+UNWINDSET +=
+
+include ../Makefile.common

--- a/tests/cbmc/proofs/s2n_stuffer_peek_char/Makefile
+++ b/tests/cbmc/proofs/s2n_stuffer_peek_char/Makefile
@@ -1,4 +1,3 @@
-# Copyright Amazon.com, Inc. or its affiliates. All Rights Reserved.
 #
 # Licensed under the Apache License, Version 2.0 (the "License"). You may not use
 # this file except in compliance with the License. A copy of the License is

--- a/tests/cbmc/proofs/s2n_stuffer_peek_char/Makefile.backup
+++ b/tests/cbmc/proofs/s2n_stuffer_peek_char/Makefile.backup
@@ -1,0 +1,35 @@
+# Copyright Amazon.com, Inc. or its affiliates. All Rights Reserved.
+#
+# Licensed under the Apache License, Version 2.0 (the "License"). You may not use
+# this file except in compliance with the License. A copy of the License is
+# located at
+#
+#     http://aws.amazon.com/apache2.0/
+#
+# or in the "license" file accompanying this file. This file is distributed on an
+# "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or
+# implied. See the License for the specific language governing permissions and
+# limitations under the License.
+
+# Expected runtime is 10 seconds.
+
+CBMCFLAGS +=
+
+PROOF_UID = s2n_stuffer_peek_char
+HARNESS_ENTRY = $(PROOF_UID)_harness
+HARNESS_FILE = $(HARNESS_ENTRY).c
+
+PROOF_SOURCES += $(PROOFDIR)/$(HARNESS_FILE)
+PROOF_SOURCES += $(PROOF_SOURCE)/cbmc_utils.c
+PROOF_SOURCES += $(PROOF_SOURCE)/make_common_datastructures.c
+
+PROJECT_SOURCES += $(SRCDIR)/stuffer/s2n_stuffer.c
+PROJECT_SOURCES += $(SRCDIR)/stuffer/s2n_stuffer_network_order.c
+PROJECT_SOURCES += $(SRCDIR)/stuffer/s2n_stuffer_text.c
+PROJECT_SOURCES += $(SRCDIR)/utils/s2n_blob.c
+PROJECT_SOURCES += $(SRCDIR)/utils/s2n_ensure.c
+PROJECT_SOURCES += $(SRCDIR)/utils/s2n_result.c
+
+UNWINDSET +=
+
+include ../Makefile.common

--- a/tests/cbmc/proofs/s2n_stuffer_peek_check_for_str/Makefile
+++ b/tests/cbmc/proofs/s2n_stuffer_peek_check_for_str/Makefile
@@ -1,4 +1,3 @@
-# Copyright Amazon.com, Inc. or its affiliates. All Rights Reserved.
 #
 # Licensed under the Apache License, Version 2.0 (the "License"). You may not use
 # this file except in compliance with the License. A copy of the License is

--- a/tests/cbmc/proofs/s2n_stuffer_peek_check_for_str/Makefile.backup
+++ b/tests/cbmc/proofs/s2n_stuffer_peek_check_for_str/Makefile.backup
@@ -1,0 +1,39 @@
+# Copyright Amazon.com, Inc. or its affiliates. All Rights Reserved.
+#
+# Licensed under the Apache License, Version 2.0 (the "License"). You may not use
+# this file except in compliance with the License. A copy of the License is
+# located at
+#
+#     http://aws.amazon.com/apache2.0/
+#
+# or in the "license" file accompanying this file. This file is distributed on an
+# "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or
+# implied. See the License for the specific language governing permissions and
+# limitations under the License.
+
+# Enough to get full coverage with 2 minute of runtime.
+MAX_STRING_LEN = 10
+DEFINES += -DMAX_STRING_LEN=$(MAX_STRING_LEN)
+
+CBMCFLAGS +=
+
+PROOF_UID = s2n_stuffer_peek_check_for_str
+HARNESS_ENTRY = $(PROOF_UID)_harness
+HARNESS_FILE = $(HARNESS_ENTRY).c
+
+PROOF_SOURCES += $(PROOFDIR)/$(HARNESS_FILE)
+PROOF_SOURCES += $(PROOF_SOURCE)/cbmc_utils.c
+PROOF_SOURCES += $(PROOF_SOURCE)/make_common_datastructures.c
+PROOF_SOURCES += $(PROOF_STUB)/s2n_calculate_stacktrace.c
+
+PROJECT_SOURCES += $(SRCDIR)/stuffer/s2n_stuffer.c
+PROJECT_SOURCES += $(SRCDIR)/stuffer/s2n_stuffer_network_order.c
+PROJECT_SOURCES += $(SRCDIR)/stuffer/s2n_stuffer_text.c
+PROJECT_SOURCES += $(SRCDIR)/utils/s2n_blob.c
+PROJECT_SOURCES += $(SRCDIR)/utils/s2n_ensure.c
+PROJECT_SOURCES += $(SRCDIR)/utils/s2n_result.c
+
+UNWINDSET += strlen.0:$(call addone,$(MAX_STRING_LEN))
+UNWINDSET += memcmp.0:$(call addone,$(MAX_STRING_LEN))
+
+include ../Makefile.common

--- a/tests/cbmc/proofs/s2n_stuffer_private_key_from_pem/Makefile.backup
+++ b/tests/cbmc/proofs/s2n_stuffer_private_key_from_pem/Makefile.backup
@@ -1,0 +1,56 @@
+# Copyright 2020 Amazon.com, Inc. or its affiliates. All Rights Reserved.
+#
+# Licensed under the Apache License, Version 2.0 (the "License"). You may not use
+# this file except in compliance with the License. A copy of the License is
+# located at
+#
+#     http://aws.amazon.com/apache2.0/
+#
+# or in the "license" file accompanying this file. This file is distributed on an
+# "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or
+# implied. See the License for the specific language governing permissions and
+# limitations under the License.
+
+# Enough to get full coverage with 7 minutes of runtime.
+MAX_BLOB_SIZE = 10
+DEFINES += -DMAX_BLOB_SIZE=$(MAX_BLOB_SIZE)
+
+CHECKFLAGS +=
+
+USE_EXTERNAL_SAT_SOLVER ?= --external-sat-solver cadical
+PROOF_UID = s2n_stuffer_private_key_from_pem
+HARNESS_ENTRY = $(PROOF_UID)_harness
+HARNESS_FILE = $(HARNESS_ENTRY).c
+
+PROOF_SOURCES += $(PROOFDIR)/$(HARNESS_FILE)
+PROOF_SOURCES += $(PROOF_SOURCE)/cbmc_utils.c
+PROOF_SOURCES += $(PROOF_SOURCE)/make_common_datastructures.c
+PROOF_SOURCES += $(PROOF_STUB)/s2n_calculate_stacktrace.c
+PROOF_SOURCES += $(PROOF_STUB)/sysconf.c
+PROOF_SOURCES += $(PROOF_STUB)/s2n_stuffer_read_expected_str.c
+PROOF_SOURCES += $(PROOF_STUB)/s2n_stuffer_skip_expected_char.c
+PROOF_SOURCES += $(PROOF_STUB)/s2n_stuffer_skip_to_char.c
+PROOF_SOURCES += $(PROOF_STUB)/s2n_stuffer_skip_whitespace.c
+PROOF_SOURCES += $(PROOF_STUB)/s2n_stuffer_read_base64.c
+PROJECT_SOURCES += $(SRCDIR)/stuffer/s2n_stuffer.c
+PROJECT_SOURCES += $(SRCDIR)/stuffer/s2n_stuffer_pem.c
+PROJECT_SOURCES += $(SRCDIR)/stuffer/s2n_stuffer_text.c
+PROJECT_SOURCES += $(SRCDIR)/stuffer/s2n_stuffer_base64.c
+PROJECT_SOURCES += $(SRCDIR)/stuffer/s2n_stuffer_network_order.c
+PROJECT_SOURCES += $(SRCDIR)/utils/s2n_blob.c
+PROJECT_SOURCES += $(SRCDIR)/utils/s2n_ensure.c
+PROJECT_SOURCES += $(SRCDIR)/utils/s2n_mem.c
+PROJECT_SOURCES += $(SRCDIR)/utils/s2n_safety.c
+PROJECT_SOURCES += $(SRCDIR)/utils/s2n_result.c
+
+# We abstract this function because manual inspection demonstrates it is unreachable.
+REMOVE_FUNCTION_BODY += s2n_stuffer_resize
+REMOVE_FUNCTION_BODY += s2n_stuffer_rewrite
+REMOVE_FUNCTION_BODY += s2n_add_overflow
+
+UNWINDSET += strlen.0:5 # size of S2N_PEM_PKCS1_RSA_PRIVATE_KEY
+UNWINDSET += strncmp.0:5 # size of S2N_PEM_END_TOKEN
+UNWINDSET += __CPROVER_file_local_s2n_stuffer_pem_c_s2n_stuffer_pem_read_contents.11:$(call addone,$(MAX_BLOB_SIZE))
+UNWINDSET += s2n_stuffer_skip_to_char.3:$(call addone,$(MAX_BLOB_SIZE))
+
+include ../Makefile.common

--- a/tests/cbmc/proofs/s2n_stuffer_raw_read/Makefile
+++ b/tests/cbmc/proofs/s2n_stuffer_raw_read/Makefile
@@ -1,4 +1,3 @@
-# Copyright Amazon.com, Inc. or its affiliates. All Rights Reserved.
 #
 # Licensed under the Apache License, Version 2.0 (the "License"). You may not use
 # this file except in compliance with the License. A copy of the License is

--- a/tests/cbmc/proofs/s2n_stuffer_raw_read/Makefile.backup
+++ b/tests/cbmc/proofs/s2n_stuffer_raw_read/Makefile.backup
@@ -1,0 +1,35 @@
+# Copyright Amazon.com, Inc. or its affiliates. All Rights Reserved.
+#
+# Licensed under the Apache License, Version 2.0 (the "License"). You may not use
+# this file except in compliance with the License. A copy of the License is
+# located at
+#
+#     http://aws.amazon.com/apache2.0/
+#
+# or in the "license" file accompanying this file. This file is distributed on an
+# "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or
+# implied. See the License for the specific language governing permissions and
+# limitations under the License.
+
+###########
+#Use the default set of CBMC flags
+CHECKFLAGS +=
+
+PROOF_UID = s2n_stuffer_raw_read
+HARNESS_ENTRY = $(PROOF_UID)_harness
+HARNESS_FILE = $(HARNESS_ENTRY).c
+
+PROOF_SOURCES += $(PROOFDIR)/$(HARNESS_FILE)
+PROOF_SOURCES += $(PROOF_SOURCE)/cbmc_utils.c
+PROOF_SOURCES += $(PROOF_SOURCE)/make_common_datastructures.c
+
+PROJECT_SOURCES += $(SRCDIR)/stuffer/s2n_stuffer.c
+PROJECT_SOURCES += $(SRCDIR)/utils/s2n_blob.c
+PROJECT_SOURCES += $(SRCDIR)/utils/s2n_ensure.c
+PROJECT_SOURCES += $(SRCDIR)/utils/s2n_result.c
+
+#No loops to unwind
+UNWINDSET +=
+###########
+
+include ../Makefile.common

--- a/tests/cbmc/proofs/s2n_stuffer_raw_write/Makefile
+++ b/tests/cbmc/proofs/s2n_stuffer_raw_write/Makefile
@@ -1,4 +1,3 @@
-# Copyright Amazon.com, Inc. or its affiliates. All Rights Reserved.
 #
 # Licensed under the Apache License, Version 2.0 (the "License"). You may not use
 # this file except in compliance with the License. A copy of the License is

--- a/tests/cbmc/proofs/s2n_stuffer_raw_write/Makefile.backup
+++ b/tests/cbmc/proofs/s2n_stuffer_raw_write/Makefile.backup
@@ -1,0 +1,40 @@
+# Copyright Amazon.com, Inc. or its affiliates. All Rights Reserved.
+#
+# Licensed under the Apache License, Version 2.0 (the "License"). You may not use
+# this file except in compliance with the License. A copy of the License is
+# located at
+#
+#     http://aws.amazon.com/apache2.0/
+#
+# or in the "license" file accompanying this file. This file is distributed on an
+# "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or
+# implied. See the License for the specific language governing permissions and
+# limitations under the License.
+
+# Expected runtime is 30 seconds.
+
+CBMCFLAGS +=
+
+PROOF_UID = s2n_stuffer_raw_write
+HARNESS_ENTRY = $(PROOF_UID)_harness
+HARNESS_FILE = $(HARNESS_ENTRY).c
+
+PROOF_SOURCES += $(PROOFDIR)/$(HARNESS_FILE)
+PROOF_SOURCES += $(PROOF_SOURCE)/cbmc_utils.c
+PROOF_SOURCES += $(PROOF_SOURCE)/make_common_datastructures.c
+
+PROJECT_SOURCES += $(SRCDIR)/stuffer/s2n_stuffer.c
+PROJECT_SOURCES += $(SRCDIR)/utils/s2n_blob.c
+PROJECT_SOURCES += $(SRCDIR)/utils/s2n_ensure.c
+PROJECT_SOURCES += $(SRCDIR)/utils/s2n_mem.c
+PROJECT_SOURCES += $(SRCDIR)/utils/s2n_result.c
+PROJECT_SOURCES += $(SRCDIR)/utils/s2n_safety.c
+
+# We abstract these functions because manual inspection demonstrates they are unreachable.
+REMOVE_FUNCTION_BODY += s2n_blob_slice
+REMOVE_FUNCTION_BODY += __CPROVER_file_local_s2n_mem_c_s2n_mem_cleanup_impl
+REMOVE_FUNCTION_BODY += s2n_stuffer_wipe
+
+UNWINDSET +=
+
+include ../Makefile.common

--- a/tests/cbmc/proofs/s2n_stuffer_read/Makefile.backup
+++ b/tests/cbmc/proofs/s2n_stuffer_read/Makefile.backup
@@ -1,0 +1,35 @@
+# Copyright 2020 Amazon.com, Inc. or its affiliates. All Rights Reserved.
+#
+# Licensed under the Apache License, Version 2.0 (the "License"). You may not use
+# this file except in compliance with the License. A copy of the License is
+# located at
+#
+#     http://aws.amazon.com/apache2.0/
+#
+# or in the "license" file accompanying this file. This file is distributed on an
+# "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or
+# implied. See the License for the specific language governing permissions and
+# limitations under the License.
+
+###########
+#Use the default set of CBMC flags
+CHECKFLAGS +=
+
+PROOF_UID = s2n_stuffer_read
+HARNESS_ENTRY = $(PROOF_UID)_harness
+HARNESS_FILE = $(HARNESS_ENTRY).c
+
+PROOF_SOURCES += $(PROOFDIR)/$(HARNESS_FILE)
+PROOF_SOURCES += $(PROOF_SOURCE)/cbmc_utils.c
+PROOF_SOURCES += $(PROOF_SOURCE)/make_common_datastructures.c
+
+PROJECT_SOURCES += $(SRCDIR)/stuffer/s2n_stuffer.c
+PROJECT_SOURCES += $(SRCDIR)/utils/s2n_blob.c
+PROJECT_SOURCES += $(SRCDIR)/utils/s2n_ensure.c
+PROJECT_SOURCES += $(SRCDIR)/utils/s2n_result.c
+
+#No loops to unwind
+UNWINDSET +=
+###########
+
+include ../Makefile.common

--- a/tests/cbmc/proofs/s2n_stuffer_read_base64/Makefile
+++ b/tests/cbmc/proofs/s2n_stuffer_read_base64/Makefile
@@ -1,4 +1,3 @@
-# Copyright Amazon.com, Inc. or its affiliates. All Rights Reserved.
 #
 # Licensed under the Apache License, Version 2.0 (the "License"). You may not use
 # this file except in compliance with the License. A copy of the License is

--- a/tests/cbmc/proofs/s2n_stuffer_read_base64/Makefile.backup
+++ b/tests/cbmc/proofs/s2n_stuffer_read_base64/Makefile.backup
@@ -1,0 +1,49 @@
+# Copyright Amazon.com, Inc. or its affiliates. All Rights Reserved.
+#
+# Licensed under the Apache License, Version 2.0 (the "License"). You may not use
+# this file except in compliance with the License. A copy of the License is
+# located at
+#
+#     http://aws.amazon.com/apache2.0/
+#
+# or in the "license" file accompanying this file. This file is distributed on an
+# "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or
+# implied. See the License for the specific language governing permissions and
+# limitations under the License.
+
+# Enough to get full coverage with 3 minutes of runtime.
+MAX_BLOB_SIZE = 4
+DEFINES += -DMAX_BLOB_SIZE=$(MAX_BLOB_SIZE)
+
+CBMCFLAGS +=
+
+PROOF_UID = s2n_stuffer_read_base64
+HARNESS_ENTRY = $(PROOF_UID)_harness
+HARNESS_FILE = $(HARNESS_ENTRY).c
+
+PROOF_SOURCES += $(PROOFDIR)/$(HARNESS_FILE)
+PROOF_SOURCES += $(PROOF_SOURCE)/cbmc_utils.c
+PROOF_SOURCES += $(PROOF_SOURCE)/make_common_datastructures.c
+PROOF_SOURCES += $(PROOF_STUB)/mlock.c
+PROOF_SOURCES += $(PROOF_STUB)/munlock.c
+PROOF_SOURCES += $(PROOF_STUB)/posix_memalign_override.c
+PROOF_SOURCES += $(PROOF_STUB)/s2n_calculate_stacktrace.c
+PROOF_SOURCES += $(PROOF_STUB)/sysconf.c
+
+PROJECT_SOURCES += $(SRCDIR)/stuffer/s2n_stuffer.c
+PROJECT_SOURCES += $(SRCDIR)/stuffer/s2n_stuffer_base64.c
+PROJECT_SOURCES += $(SRCDIR)/stuffer/s2n_stuffer_network_order.c
+PROJECT_SOURCES += $(SRCDIR)/utils/s2n_blob.c
+PROJECT_SOURCES += $(SRCDIR)/utils/s2n_ensure.c
+PROJECT_SOURCES += $(SRCDIR)/utils/s2n_result.c
+PROJECT_SOURCES += $(SRCDIR)/utils/s2n_safety.c
+PROJECT_SOURCES += $(SRCDIR)/utils/s2n_mem.c
+
+# We abstract these functions because manual inspection demonstrates they are unreachable.
+REMOVE_FUNCTION_BODY += __CPROVER_file_local_s2n_mem_c_s2n_mem_cleanup_impl
+REMOVE_FUNCTION_BODY += s2n_blob_slice
+REMOVE_FUNCTION_BODY += s2n_stuffer_wipe
+
+UNWINDSET += s2n_stuffer_read_base64.19:$(MAX_BLOB_SIZE)
+
+include ../Makefile.common

--- a/tests/cbmc/proofs/s2n_stuffer_read_bytes/Makefile
+++ b/tests/cbmc/proofs/s2n_stuffer_read_bytes/Makefile
@@ -1,4 +1,3 @@
-# Copyright Amazon.com, Inc. or its affiliates. All Rights Reserved.
 #
 # Licensed under the Apache License, Version 2.0 (the "License"). You may not use
 # this file except in compliance with the License. A copy of the License is

--- a/tests/cbmc/proofs/s2n_stuffer_read_bytes/Makefile.backup
+++ b/tests/cbmc/proofs/s2n_stuffer_read_bytes/Makefile.backup
@@ -1,0 +1,35 @@
+# Copyright Amazon.com, Inc. or its affiliates. All Rights Reserved.
+#
+# Licensed under the Apache License, Version 2.0 (the "License"). You may not use
+# this file except in compliance with the License. A copy of the License is
+# located at
+#
+#     http://aws.amazon.com/apache2.0/
+#
+# or in the "license" file accompanying this file. This file is distributed on an
+# "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or
+# implied. See the License for the specific language governing permissions and
+# limitations under the License.
+
+###########
+#Use the default set of CBMC flags
+CHECKFLAGS +=
+
+PROOF_UID = s2n_stuffer_read_bytes
+HARNESS_ENTRY = $(PROOF_UID)_harness
+HARNESS_FILE = $(HARNESS_ENTRY).c
+
+PROOF_SOURCES += $(PROOFDIR)/$(HARNESS_FILE)
+PROOF_SOURCES += $(PROOF_SOURCE)/cbmc_utils.c
+PROOF_SOURCES += $(PROOF_SOURCE)/make_common_datastructures.c
+
+PROJECT_SOURCES += $(SRCDIR)/stuffer/s2n_stuffer.c
+PROJECT_SOURCES += $(SRCDIR)/utils/s2n_blob.c
+PROJECT_SOURCES += $(SRCDIR)/utils/s2n_ensure.c
+PROJECT_SOURCES += $(SRCDIR)/utils/s2n_result.c
+
+#No loops to unwind
+UNWINDSET +=
+###########
+
+include ../Makefile.common

--- a/tests/cbmc/proofs/s2n_stuffer_read_expected_str/Makefile
+++ b/tests/cbmc/proofs/s2n_stuffer_read_expected_str/Makefile
@@ -1,4 +1,3 @@
-# Copyright Amazon.com, Inc. or its affiliates. All Rights Reserved.
 #
 # Licensed under the Apache License, Version 2.0 (the "License"). You may not use
 # this file except in compliance with the License. A copy of the License is

--- a/tests/cbmc/proofs/s2n_stuffer_read_expected_str/Makefile.backup
+++ b/tests/cbmc/proofs/s2n_stuffer_read_expected_str/Makefile.backup
@@ -1,0 +1,37 @@
+# Copyright Amazon.com, Inc. or its affiliates. All Rights Reserved.
+#
+# Licensed under the Apache License, Version 2.0 (the "License"). You may not use
+# this file except in compliance with the License. A copy of the License is
+# located at
+#
+#     http://aws.amazon.com/apache2.0/
+#
+# or in the "license" file accompanying this file. This file is distributed on an
+# "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or
+# implied. See the License for the specific language governing permissions and
+# limitations under the License.
+
+# Enough to get full coverage with 1 minute of runtime.
+MAX_STRING_LEN = 10
+DEFINES += -DMAX_STRING_LEN=$(MAX_STRING_LEN)
+
+PROOF_UID = s2n_stuffer_read_expected_str
+HARNESS_ENTRY = $(PROOF_UID)_harness
+HARNESS_FILE = $(HARNESS_ENTRY).c
+
+PROOF_SOURCES += $(PROOFDIR)/$(HARNESS_FILE)
+PROOF_SOURCES += $(PROOF_SOURCE)/cbmc_utils.c
+PROOF_SOURCES += $(PROOF_SOURCE)/make_common_datastructures.c
+PROOF_SOURCES += $(PROOF_STUB)/s2n_calculate_stacktrace.c
+
+PROJECT_SOURCES += $(SRCDIR)/stuffer/s2n_stuffer.c
+PROJECT_SOURCES += $(SRCDIR)/stuffer/s2n_stuffer_network_order.c
+PROJECT_SOURCES += $(SRCDIR)/stuffer/s2n_stuffer_text.c
+PROJECT_SOURCES += $(SRCDIR)/utils/s2n_blob.c
+PROJECT_SOURCES += $(SRCDIR)/utils/s2n_ensure.c
+PROJECT_SOURCES += $(SRCDIR)/utils/s2n_result.c
+
+UNWINDSET += strlen.0:$(call addone,$(MAX_STRING_LEN))
+UNWINDSET += memcmp.0:$(call addone,$(MAX_STRING_LEN))
+
+include ../Makefile.common

--- a/tests/cbmc/proofs/s2n_stuffer_read_line/Makefile
+++ b/tests/cbmc/proofs/s2n_stuffer_read_line/Makefile
@@ -1,4 +1,3 @@
-# Copyright Amazon.com, Inc. or its affiliates. All Rights Reserved.
 #
 # Licensed under the Apache License, Version 2.0 (the "License"). You may not use
 # this file except in compliance with the License. A copy of the License is

--- a/tests/cbmc/proofs/s2n_stuffer_read_line/Makefile.backup
+++ b/tests/cbmc/proofs/s2n_stuffer_read_line/Makefile.backup
@@ -1,0 +1,48 @@
+# Copyright Amazon.com, Inc. or its affiliates. All Rights Reserved.
+#
+# Licensed under the Apache License, Version 2.0 (the "License"). You may not use
+# this file except in compliance with the License. A copy of the License is
+# located at
+#
+#     http://aws.amazon.com/apache2.0/
+#
+# or in the "license" file accompanying this file. This file is distributed on an
+# "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or
+# implied. See the License for the specific language governing permissions and
+# limitations under the License.
+
+# Enough to get full coverage with 2 minutes of runtime.
+MAX_BLOB_SIZE = 3
+DEFINES += -DMAX_BLOB_SIZE=$(MAX_BLOB_SIZE)
+
+CHECKFLAGS +=
+
+PROOF_UID = s2n_stuffer_read_line
+HARNESS_ENTRY = $(PROOF_UID)_harness
+HARNESS_FILE = $(HARNESS_ENTRY).c
+
+PROOF_SOURCES += $(PROOFDIR)/$(HARNESS_FILE)
+PROOF_SOURCES += $(PROOF_SOURCE)/cbmc_utils.c
+PROOF_SOURCES += $(PROOF_SOURCE)/make_common_datastructures.c
+PROOF_SOURCES += $(PROOF_STUB)/mlock.c
+PROOF_SOURCES += $(PROOF_STUB)/munlock.c
+PROOF_SOURCES += $(PROOF_STUB)/posix_memalign_override.c
+PROOF_SOURCES += $(PROOF_STUB)/s2n_calculate_stacktrace.c
+PROOF_SOURCES += $(PROOF_STUB)/sysconf.c
+
+PROJECT_SOURCES += $(SRCDIR)/stuffer/s2n_stuffer.c
+PROJECT_SOURCES += $(SRCDIR)/stuffer/s2n_stuffer_text.c
+PROJECT_SOURCES += $(SRCDIR)/utils/s2n_blob.c
+PROJECT_SOURCES += $(SRCDIR)/utils/s2n_ensure.c
+PROJECT_SOURCES += $(SRCDIR)/utils/s2n_mem.c
+PROJECT_SOURCES += $(SRCDIR)/utils/s2n_safety.c
+PROJECT_SOURCES += $(SRCDIR)/utils/s2n_result.c
+
+# We abstract these functions because manual inspection demonstrates they are unreachable.
+REMOVE_FUNCTION_BODY += __CPROVER_file_local_s2n_mem_c_s2n_mem_cleanup_impl
+REMOVE_FUNCTION_BODY += s2n_blob_slice
+REMOVE_FUNCTION_BODY += s2n_stuffer_wipe
+
+UNWINDSET += s2n_stuffer_read_token.2:$(call addone,$(MAX_BLOB_SIZE))
+
+include ../Makefile.common

--- a/tests/cbmc/proofs/s2n_stuffer_read_token/Makefile
+++ b/tests/cbmc/proofs/s2n_stuffer_read_token/Makefile
@@ -1,4 +1,3 @@
-# Copyright Amazon.com, Inc. or its affiliates. All Rights Reserved.
 #
 # Licensed under the Apache License, Version 2.0 (the "License"). You may not use
 # this file except in compliance with the License. A copy of the License is

--- a/tests/cbmc/proofs/s2n_stuffer_read_token/Makefile.backup
+++ b/tests/cbmc/proofs/s2n_stuffer_read_token/Makefile.backup
@@ -1,0 +1,45 @@
+# Copyright Amazon.com, Inc. or its affiliates. All Rights Reserved.
+#
+# Licensed under the Apache License, Version 2.0 (the "License"). You may not use
+# this file except in compliance with the License. A copy of the License is
+# located at
+#
+#     http://aws.amazon.com/apache2.0/
+#
+# or in the "license" file accompanying this file. This file is distributed on an
+# "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or
+# implied. See the License for the specific language governing permissions and
+# limitations under the License.
+
+# Enough to get full coverage with 40 seconds of runtime.
+MAX_BLOB_SIZE = 3
+DEFINES += -DMAX_BLOB_SIZE=$(MAX_BLOB_SIZE)
+
+CBMCFLAGS +=
+
+PROOF_UID = s2n_stuffer_read_token
+HARNESS_ENTRY = $(PROOF_UID)_harness
+HARNESS_FILE = $(HARNESS_ENTRY).c
+
+PROOF_SOURCES += $(PROOFDIR)/$(HARNESS_FILE)
+PROOF_SOURCES += $(PROOF_SOURCE)/cbmc_utils.c
+PROOF_SOURCES += $(PROOF_SOURCE)/make_common_datastructures.c
+PROOF_SOURCES += $(PROOF_STUB)/munlock.c
+PROOF_SOURCES += $(PROOF_STUB)/s2n_calculate_stacktrace.c
+PROOF_SOURCES += $(PROOF_STUB)/sysconf.c
+
+PROJECT_SOURCES += $(SRCDIR)/stuffer/s2n_stuffer.c
+PROJECT_SOURCES += $(SRCDIR)/stuffer/s2n_stuffer_text.c
+PROJECT_SOURCES += $(SRCDIR)/utils/s2n_blob.c
+PROJECT_SOURCES += $(SRCDIR)/utils/s2n_ensure.c
+PROJECT_SOURCES += $(SRCDIR)/utils/s2n_mem.c
+PROJECT_SOURCES += $(SRCDIR)/utils/s2n_safety.c
+PROJECT_SOURCES += $(SRCDIR)/utils/s2n_result.c
+
+# We abstract these functions because manual inspection demonstrates they are unreachable.
+REMOVE_FUNCTION_BODY += s2n_blob_slice
+REMOVE_FUNCTION_BODY += s2n_stuffer_wipe
+
+UNWINDSET += s2n_stuffer_read_token.2:$(call addone,$(MAX_BLOB_SIZE))
+
+include ../Makefile.common

--- a/tests/cbmc/proofs/s2n_stuffer_read_uint16/Makefile
+++ b/tests/cbmc/proofs/s2n_stuffer_read_uint16/Makefile
@@ -1,4 +1,3 @@
-# Copyright Amazon.com, Inc. or its affiliates. All Rights Reserved.
 #
 # Licensed under the Apache License, Version 2.0 (the "License"). You may not use
 # this file except in compliance with the License. A copy of the License is

--- a/tests/cbmc/proofs/s2n_stuffer_read_uint16/Makefile.backup
+++ b/tests/cbmc/proofs/s2n_stuffer_read_uint16/Makefile.backup
@@ -1,0 +1,33 @@
+# Copyright Amazon.com, Inc. or its affiliates. All Rights Reserved.
+#
+# Licensed under the Apache License, Version 2.0 (the "License"). You may not use
+# this file except in compliance with the License. A copy of the License is
+# located at
+#
+#     http://aws.amazon.com/apache2.0/
+#
+# or in the "license" file accompanying this file. This file is distributed on an
+# "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or
+# implied. See the License for the specific language governing permissions and
+# limitations under the License.
+
+# Expected runtime is 10 seconds.
+CBMCFLAGS +=
+
+PROOF_UID = s2n_stuffer_read_uint16
+HARNESS_ENTRY = $(PROOF_UID)_harness
+HARNESS_FILE = $(HARNESS_ENTRY).c
+
+PROOF_SOURCES += $(PROOFDIR)/$(HARNESS_FILE)
+PROOF_SOURCES += $(PROOF_SOURCE)/cbmc_utils.c
+PROOF_SOURCES += $(PROOF_SOURCE)/make_common_datastructures.c
+
+PROJECT_SOURCES += $(SRCDIR)/stuffer/s2n_stuffer.c
+PROJECT_SOURCES += $(SRCDIR)/stuffer/s2n_stuffer_network_order.c
+PROJECT_SOURCES += $(SRCDIR)/utils/s2n_blob.c
+PROJECT_SOURCES += $(SRCDIR)/utils/s2n_ensure.c
+PROJECT_SOURCES += $(SRCDIR)/utils/s2n_result.c
+
+UNWINDSET +=
+
+include ../Makefile.common

--- a/tests/cbmc/proofs/s2n_stuffer_read_uint24/Makefile
+++ b/tests/cbmc/proofs/s2n_stuffer_read_uint24/Makefile
@@ -1,4 +1,3 @@
-# Copyright Amazon.com, Inc. or its affiliates. All Rights Reserved.
 #
 # Licensed under the Apache License, Version 2.0 (the "License"). You may not use
 # this file except in compliance with the License. A copy of the License is

--- a/tests/cbmc/proofs/s2n_stuffer_read_uint24/Makefile.backup
+++ b/tests/cbmc/proofs/s2n_stuffer_read_uint24/Makefile.backup
@@ -1,0 +1,33 @@
+# Copyright Amazon.com, Inc. or its affiliates. All Rights Reserved.
+#
+# Licensed under the Apache License, Version 2.0 (the "License"). You may not use
+# this file except in compliance with the License. A copy of the License is
+# located at
+#
+#     http://aws.amazon.com/apache2.0/
+#
+# or in the "license" file accompanying this file. This file is distributed on an
+# "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or
+# implied. See the License for the specific language governing permissions and
+# limitations under the License.
+
+# Expected runtime is 10 seconds.
+CBMCFLAGS +=
+
+PROOF_UID = s2n_stuffer_read_uint24
+HARNESS_ENTRY = $(PROOF_UID)_harness
+HARNESS_FILE = $(HARNESS_ENTRY).c
+
+PROOF_SOURCES += $(PROOFDIR)/$(HARNESS_FILE)
+PROOF_SOURCES += $(PROOF_SOURCE)/cbmc_utils.c
+PROOF_SOURCES += $(PROOF_SOURCE)/make_common_datastructures.c
+
+PROJECT_SOURCES += $(SRCDIR)/stuffer/s2n_stuffer.c
+PROJECT_SOURCES += $(SRCDIR)/stuffer/s2n_stuffer_network_order.c
+PROJECT_SOURCES += $(SRCDIR)/utils/s2n_blob.c
+PROJECT_SOURCES += $(SRCDIR)/utils/s2n_ensure.c
+PROJECT_SOURCES += $(SRCDIR)/utils/s2n_result.c
+
+UNWINDSET +=
+
+include ../Makefile.common

--- a/tests/cbmc/proofs/s2n_stuffer_read_uint32/Makefile
+++ b/tests/cbmc/proofs/s2n_stuffer_read_uint32/Makefile
@@ -1,4 +1,3 @@
-# Copyright Amazon.com, Inc. or its affiliates. All Rights Reserved.
 #
 # Licensed under the Apache License, Version 2.0 (the "License"). You may not use
 # this file except in compliance with the License. A copy of the License is

--- a/tests/cbmc/proofs/s2n_stuffer_read_uint32/Makefile.backup
+++ b/tests/cbmc/proofs/s2n_stuffer_read_uint32/Makefile.backup
@@ -1,0 +1,33 @@
+# Copyright Amazon.com, Inc. or its affiliates. All Rights Reserved.
+#
+# Licensed under the Apache License, Version 2.0 (the "License"). You may not use
+# this file except in compliance with the License. A copy of the License is
+# located at
+#
+#     http://aws.amazon.com/apache2.0/
+#
+# or in the "license" file accompanying this file. This file is distributed on an
+# "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or
+# implied. See the License for the specific language governing permissions and
+# limitations under the License.
+
+# Expected runtime is 10 seconds.
+CBMCFLAGS +=
+
+PROOF_UID = s2n_stuffer_read_uint32
+HARNESS_ENTRY = $(PROOF_UID)_harness
+HARNESS_FILE = $(HARNESS_ENTRY).c
+
+PROOF_SOURCES += $(PROOFDIR)/$(HARNESS_FILE)
+PROOF_SOURCES += $(PROOF_SOURCE)/cbmc_utils.c
+PROOF_SOURCES += $(PROOF_SOURCE)/make_common_datastructures.c
+
+PROJECT_SOURCES += $(SRCDIR)/stuffer/s2n_stuffer.c
+PROJECT_SOURCES += $(SRCDIR)/stuffer/s2n_stuffer_network_order.c
+PROJECT_SOURCES += $(SRCDIR)/utils/s2n_blob.c
+PROJECT_SOURCES += $(SRCDIR)/utils/s2n_ensure.c
+PROJECT_SOURCES += $(SRCDIR)/utils/s2n_result.c
+
+UNWINDSET +=
+
+include ../Makefile.common

--- a/tests/cbmc/proofs/s2n_stuffer_read_uint64/Makefile
+++ b/tests/cbmc/proofs/s2n_stuffer_read_uint64/Makefile
@@ -1,4 +1,3 @@
-# Copyright Amazon.com, Inc. or its affiliates. All Rights Reserved.
 #
 # Licensed under the Apache License, Version 2.0 (the "License"). You may not use
 # this file except in compliance with the License. A copy of the License is

--- a/tests/cbmc/proofs/s2n_stuffer_read_uint64/Makefile.backup
+++ b/tests/cbmc/proofs/s2n_stuffer_read_uint64/Makefile.backup
@@ -1,0 +1,33 @@
+# Copyright Amazon.com, Inc. or its affiliates. All Rights Reserved.
+#
+# Licensed under the Apache License, Version 2.0 (the "License"). You may not use
+# this file except in compliance with the License. A copy of the License is
+# located at
+#
+#     http://aws.amazon.com/apache2.0/
+#
+# or in the "license" file accompanying this file. This file is distributed on an
+# "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or
+# implied. See the License for the specific language governing permissions and
+# limitations under the License.
+
+# Expected runtime is 20 seconds.
+CBMCFLAGS +=
+
+PROOF_UID = s2n_stuffer_read_uint64
+HARNESS_ENTRY = $(PROOF_UID)_harness
+HARNESS_FILE = $(HARNESS_ENTRY).c
+
+PROOF_SOURCES += $(PROOFDIR)/$(HARNESS_FILE)
+PROOF_SOURCES += $(PROOF_SOURCE)/cbmc_utils.c
+PROOF_SOURCES += $(PROOF_SOURCE)/make_common_datastructures.c
+
+PROJECT_SOURCES += $(SRCDIR)/stuffer/s2n_stuffer.c
+PROJECT_SOURCES += $(SRCDIR)/stuffer/s2n_stuffer_network_order.c
+PROJECT_SOURCES += $(SRCDIR)/utils/s2n_blob.c
+PROJECT_SOURCES += $(SRCDIR)/utils/s2n_ensure.c
+PROJECT_SOURCES += $(SRCDIR)/utils/s2n_result.c
+
+UNWINDSET +=
+
+include ../Makefile.common

--- a/tests/cbmc/proofs/s2n_stuffer_read_uint8/Makefile
+++ b/tests/cbmc/proofs/s2n_stuffer_read_uint8/Makefile
@@ -1,4 +1,3 @@
-# Copyright Amazon.com, Inc. or its affiliates. All Rights Reserved.
 #
 # Licensed under the Apache License, Version 2.0 (the "License"). You may not use
 # this file except in compliance with the License. A copy of the License is

--- a/tests/cbmc/proofs/s2n_stuffer_read_uint8/Makefile.backup
+++ b/tests/cbmc/proofs/s2n_stuffer_read_uint8/Makefile.backup
@@ -1,0 +1,33 @@
+# Copyright Amazon.com, Inc. or its affiliates. All Rights Reserved.
+#
+# Licensed under the Apache License, Version 2.0 (the "License"). You may not use
+# this file except in compliance with the License. A copy of the License is
+# located at
+#
+#     http://aws.amazon.com/apache2.0/
+#
+# or in the "license" file accompanying this file. This file is distributed on an
+# "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or
+# implied. See the License for the specific language governing permissions and
+# limitations under the License.
+
+# Expected runtime is 10 seconds.
+CBMCFLAGS +=
+
+PROOF_UID = s2n_stuffer_read_uint8
+HARNESS_ENTRY = $(PROOF_UID)_harness
+HARNESS_FILE = $(HARNESS_ENTRY).c
+
+PROOF_SOURCES += $(PROOFDIR)/$(HARNESS_FILE)
+PROOF_SOURCES += $(PROOF_SOURCE)/cbmc_utils.c
+PROOF_SOURCES += $(PROOF_SOURCE)/make_common_datastructures.c
+
+PROJECT_SOURCES += $(SRCDIR)/stuffer/s2n_stuffer.c
+PROJECT_SOURCES += $(SRCDIR)/stuffer/s2n_stuffer_network_order.c
+PROJECT_SOURCES += $(SRCDIR)/utils/s2n_blob.c
+PROJECT_SOURCES += $(SRCDIR)/utils/s2n_ensure.c
+PROJECT_SOURCES += $(SRCDIR)/utils/s2n_result.c
+
+UNWINDSET +=
+
+include ../Makefile.common

--- a/tests/cbmc/proofs/s2n_stuffer_recv_from_fd/Makefile
+++ b/tests/cbmc/proofs/s2n_stuffer_recv_from_fd/Makefile
@@ -1,4 +1,3 @@
-# Copyright Amazon.com, Inc. or its affiliates. All Rights Reserved.
 #
 # Licensed under the Apache License, Version 2.0 (the "License"). You may not use
 # this file except in compliance with the License. A copy of the License is

--- a/tests/cbmc/proofs/s2n_stuffer_recv_from_fd/Makefile.backup
+++ b/tests/cbmc/proofs/s2n_stuffer_recv_from_fd/Makefile.backup
@@ -1,0 +1,48 @@
+# Copyright Amazon.com, Inc. or its affiliates. All Rights Reserved.
+#
+# Licensed under the Apache License, Version 2.0 (the "License"). You may not use
+# this file except in compliance with the License. A copy of the License is
+# located at
+#
+#     http://aws.amazon.com/apache2.0/
+#
+# or in the "license" file accompanying this file. This file is distributed on an
+# "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or
+# implied. See the License for the specific language governing permissions and
+# limitations under the License.
+
+# Expected runtime of 2 minutes.
+
+CBMCFLAGS +=
+
+PROOF_UID = s2n_stuffer_recv_from_fd
+HARNESS_ENTRY = $(PROOF_UID)_harness
+HARNESS_FILE = $(HARNESS_ENTRY).c
+
+PROOF_SOURCES += $(PROOFDIR)/$(HARNESS_FILE)
+PROOF_SOURCES += $(PROOF_SOURCE)/cbmc_utils.c
+PROOF_SOURCES += $(PROOF_SOURCE)/make_common_datastructures.c
+PROOF_SOURCES += $(PROOF_STUB)/mlock.c
+PROOF_SOURCES += $(PROOF_STUB)/munlock.c
+PROOF_SOURCES += $(PROOF_STUB)/posix_memalign_override.c
+PROOF_SOURCES += $(PROOF_STUB)/read.c
+PROOF_SOURCES += $(PROOF_STUB)/s2n_calculate_stacktrace.c
+PROOF_SOURCES += $(PROOF_STUB)/sysconf.c
+
+PROJECT_SOURCES += $(SRCDIR)/error/s2n_errno.c
+PROJECT_SOURCES += $(SRCDIR)/stuffer/s2n_stuffer.c
+PROJECT_SOURCES += $(SRCDIR)/stuffer/s2n_stuffer_file.c
+PROJECT_SOURCES += $(SRCDIR)/utils/s2n_blob.c
+PROJECT_SOURCES += $(SRCDIR)/utils/s2n_ensure.c
+PROJECT_SOURCES += $(SRCDIR)/utils/s2n_mem.c
+PROJECT_SOURCES += $(SRCDIR)/utils/s2n_safety.c
+PROJECT_SOURCES += $(SRCDIR)/utils/s2n_result.c
+
+# We abstract these functions because manual inspection demonstrates they are unreachable.
+REMOVE_FUNCTION_BODY += __CPROVER_file_local_s2n_mem_c_s2n_mem_cleanup_impl
+REMOVE_FUNCTION_BODY += s2n_blob_slice
+REMOVE_FUNCTION_BODY += s2n_stuffer_wipe
+
+UNWINDSET += s2n_stuffer_recv_from_fd.5:3
+
+include ../Makefile.common

--- a/tests/cbmc/proofs/s2n_stuffer_reread/Makefile
+++ b/tests/cbmc/proofs/s2n_stuffer_reread/Makefile
@@ -1,4 +1,3 @@
-# Copyright Amazon.com, Inc. or its affiliates. All Rights Reserved.
 #
 # Licensed under the Apache License, Version 2.0 (the "License"). You may not use
 # this file except in compliance with the License. A copy of the License is

--- a/tests/cbmc/proofs/s2n_stuffer_reread/Makefile.backup
+++ b/tests/cbmc/proofs/s2n_stuffer_reread/Makefile.backup
@@ -1,0 +1,35 @@
+# Copyright Amazon.com, Inc. or its affiliates. All Rights Reserved.
+#
+# Licensed under the Apache License, Version 2.0 (the "License"). You may not use
+# this file except in compliance with the License. A copy of the License is
+# located at
+#
+#     http://aws.amazon.com/apache2.0/
+#
+# or in the "license" file accompanying this file. This file is distributed on an
+# "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or
+# implied. See the License for the specific language governing permissions and
+# limitations under the License.
+
+###########
+#Use the default set of CBMC flags
+CHECKFLAGS +=
+
+PROOF_UID = s2n_stuffer_reread
+HARNESS_ENTRY = $(PROOF_UID)_harness
+HARNESS_FILE = $(HARNESS_ENTRY).c
+
+PROOF_SOURCES += $(PROOFDIR)/$(HARNESS_FILE)
+PROOF_SOURCES += $(PROOF_SOURCE)/cbmc_utils.c
+PROOF_SOURCES += $(PROOF_SOURCE)/make_common_datastructures.c
+
+PROJECT_SOURCES += $(SRCDIR)/stuffer/s2n_stuffer.c
+PROJECT_SOURCES += $(SRCDIR)/utils/s2n_blob.c
+PROJECT_SOURCES += $(SRCDIR)/utils/s2n_ensure.c
+PROJECT_SOURCES += $(SRCDIR)/utils/s2n_result.c
+
+#No loops to unwind
+UNWINDSET +=
+###########
+
+include ../Makefile.common

--- a/tests/cbmc/proofs/s2n_stuffer_reserve/Makefile
+++ b/tests/cbmc/proofs/s2n_stuffer_reserve/Makefile
@@ -1,4 +1,3 @@
-# Copyright Amazon.com, Inc. or its affiliates. All Rights Reserved.
 #
 # Licensed under the Apache License, Version 2.0 (the "License"). You may not use
 # this file except in compliance with the License. A copy of the License is

--- a/tests/cbmc/proofs/s2n_stuffer_reserve/Makefile.backup
+++ b/tests/cbmc/proofs/s2n_stuffer_reserve/Makefile.backup
@@ -1,0 +1,46 @@
+# Copyright Amazon.com, Inc. or its affiliates. All Rights Reserved.
+#
+# Licensed under the Apache License, Version 2.0 (the "License"). You may not use
+# this file except in compliance with the License. A copy of the License is
+# located at
+#
+#     http://aws.amazon.com/apache2.0/
+#
+# or in the "license" file accompanying this file. This file is distributed on an
+# "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or
+# implied. See the License for the specific language governing permissions and
+# limitations under the License.
+
+# Expected runtime is 30 seconds.
+
+CBMCFLAGS +=
+
+PROOF_UID = s2n_stuffer_reserve
+HARNESS_ENTRY = $(PROOF_UID)_harness
+HARNESS_FILE = $(HARNESS_ENTRY).c
+
+PROOF_SOURCES += $(PROOFDIR)/$(HARNESS_FILE)
+PROOF_SOURCES += $(PROOF_SOURCE)/cbmc_utils.c
+PROOF_SOURCES += $(PROOF_SOURCE)/make_common_datastructures.c
+PROOF_SOURCES += $(PROOF_STUB)/mlock.c
+PROOF_SOURCES += $(PROOF_STUB)/munlock.c
+PROOF_SOURCES += $(PROOF_STUB)/posix_memalign_override.c
+PROOF_SOURCES += $(PROOF_STUB)/s2n_calculate_stacktrace.c
+PROOF_SOURCES += $(PROOF_STUB)/sysconf.c
+
+PROJECT_SOURCES += $(SRCDIR)/stuffer/s2n_stuffer.c
+PROJECT_SOURCES += $(SRCDIR)/stuffer/s2n_stuffer_network_order.c
+PROJECT_SOURCES += $(SRCDIR)/utils/s2n_blob.c
+PROJECT_SOURCES += $(SRCDIR)/utils/s2n_ensure.c
+PROJECT_SOURCES += $(SRCDIR)/utils/s2n_mem.c
+PROJECT_SOURCES += $(SRCDIR)/utils/s2n_safety.c
+PROJECT_SOURCES += $(SRCDIR)/utils/s2n_result.c
+
+# We abstract these functions because manual inspection demonstrates they are unreachable.
+REMOVE_FUNCTION_BODY += __CPROVER_file_local_s2n_mem_c_s2n_mem_cleanup_impl
+REMOVE_FUNCTION_BODY += s2n_blob_slice
+REMOVE_FUNCTION_BODY += s2n_stuffer_wipe
+
+UNWINDSET +=
+
+include ../Makefile.common

--- a/tests/cbmc/proofs/s2n_stuffer_reserve_space/Makefile
+++ b/tests/cbmc/proofs/s2n_stuffer_reserve_space/Makefile
@@ -1,4 +1,3 @@
-# Copyright Amazon.com, Inc. or its affiliates. All Rights Reserved.
 #
 # Licensed under the Apache License, Version 2.0 (the "License"). You may not use
 # this file except in compliance with the License. A copy of the License is

--- a/tests/cbmc/proofs/s2n_stuffer_reserve_space/Makefile.backup
+++ b/tests/cbmc/proofs/s2n_stuffer_reserve_space/Makefile.backup
@@ -1,0 +1,44 @@
+# Copyright Amazon.com, Inc. or its affiliates. All Rights Reserved.
+#
+# Licensed under the Apache License, Version 2.0 (the "License"). You may not use
+# this file except in compliance with the License. A copy of the License is
+# located at
+#
+#     http://aws.amazon.com/apache2.0/
+#
+# or in the "license" file accompanying this file. This file is distributed on an
+# "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or
+# implied. See the License for the specific language governing permissions and
+# limitations under the License.
+
+# Expected runtime is 20 seconds.
+
+
+CBMCFLAGS +=
+
+PROOF_UID = s2n_stuffer_reserve_space
+HARNESS_ENTRY = $(PROOF_UID)_harness
+HARNESS_FILE = $(HARNESS_ENTRY).c
+
+PROOF_SOURCES += $(PROOFDIR)/$(HARNESS_FILE)
+PROOF_SOURCES += $(PROOF_SOURCE)/cbmc_utils.c
+PROOF_SOURCES += $(PROOF_SOURCE)/make_common_datastructures.c
+
+PROOF_SOURCES += $(PROOF_STUB)/s2n_calculate_stacktrace.c
+
+PROJECT_SOURCES += $(SRCDIR)/error/s2n_errno.c
+PROJECT_SOURCES += $(SRCDIR)/stuffer/s2n_stuffer.c
+PROJECT_SOURCES += $(SRCDIR)/utils/s2n_blob.c
+PROJECT_SOURCES += $(SRCDIR)/utils/s2n_ensure.c
+PROJECT_SOURCES += $(SRCDIR)/utils/s2n_mem.c
+PROJECT_SOURCES += $(SRCDIR)/utils/s2n_safety.c
+PROJECT_SOURCES += $(SRCDIR)/utils/s2n_result.c
+
+# We abstract these functions because manual inspection demonstrates they are unreachable.
+REMOVE_FUNCTION_BODY += s2n_blob_slice
+REMOVE_FUNCTION_BODY += s2n_calculate_stacktrace
+REMOVE_FUNCTION_BODY += s2n_stuffer_wipe
+
+UNWINDSET +=
+
+include ../Makefile.common

--- a/tests/cbmc/proofs/s2n_stuffer_reserve_uint16/Makefile
+++ b/tests/cbmc/proofs/s2n_stuffer_reserve_uint16/Makefile
@@ -1,4 +1,3 @@
-# Copyright Amazon.com, Inc. or its affiliates. All Rights Reserved.
 #
 # Licensed under the Apache License, Version 2.0 (the "License"). You may not use
 # this file except in compliance with the License. A copy of the License is

--- a/tests/cbmc/proofs/s2n_stuffer_reserve_uint16/Makefile.backup
+++ b/tests/cbmc/proofs/s2n_stuffer_reserve_uint16/Makefile.backup
@@ -1,0 +1,43 @@
+# Copyright Amazon.com, Inc. or its affiliates. All Rights Reserved.
+#
+# Licensed under the Apache License, Version 2.0 (the "License"). You may not use
+# this file except in compliance with the License. A copy of the License is
+# located at
+#
+#     http://aws.amazon.com/apache2.0/
+#
+# or in the "license" file accompanying this file. This file is distributed on an
+# "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or
+# implied. See the License for the specific language governing permissions and
+# limitations under the License.
+
+# Expected runtime is 20 seconds.
+
+CBMCFLAGS +=
+
+PROOF_UID = s2n_stuffer_reserve_uint16
+HARNESS_ENTRY = $(PROOF_UID)_harness
+HARNESS_FILE = $(HARNESS_ENTRY).c
+
+PROOF_SOURCES += $(PROOFDIR)/$(HARNESS_FILE)
+PROOF_SOURCES += $(PROOF_SOURCE)/cbmc_utils.c
+PROOF_SOURCES += $(PROOF_SOURCE)/make_common_datastructures.c
+PROOF_SOURCES += $(PROOF_STUB)/munlock.c
+PROOF_SOURCES += $(PROOF_STUB)/s2n_calculate_stacktrace.c
+PROOF_SOURCES += $(PROOF_STUB)/sysconf.c
+
+PROJECT_SOURCES += $(SRCDIR)/stuffer/s2n_stuffer.c
+PROJECT_SOURCES += $(SRCDIR)/stuffer/s2n_stuffer_network_order.c
+PROJECT_SOURCES += $(SRCDIR)/utils/s2n_blob.c
+PROJECT_SOURCES += $(SRCDIR)/utils/s2n_ensure.c
+PROJECT_SOURCES += $(SRCDIR)/utils/s2n_mem.c
+PROJECT_SOURCES += $(SRCDIR)/utils/s2n_safety.c
+PROJECT_SOURCES += $(SRCDIR)/utils/s2n_result.c
+
+# We abstract these functions because manual inspection demonstrates they are unreachable.
+REMOVE_FUNCTION_BODY += s2n_blob_slice
+REMOVE_FUNCTION_BODY += s2n_stuffer_wipe
+
+UNWINDSET +=
+
+include ../Makefile.common

--- a/tests/cbmc/proofs/s2n_stuffer_reserve_uint24/Makefile
+++ b/tests/cbmc/proofs/s2n_stuffer_reserve_uint24/Makefile
@@ -1,4 +1,3 @@
-# Copyright Amazon.com, Inc. or its affiliates. All Rights Reserved.
 #
 # Licensed under the Apache License, Version 2.0 (the "License"). You may not use
 # this file except in compliance with the License. A copy of the License is

--- a/tests/cbmc/proofs/s2n_stuffer_reserve_uint24/Makefile.backup
+++ b/tests/cbmc/proofs/s2n_stuffer_reserve_uint24/Makefile.backup
@@ -1,0 +1,43 @@
+# Copyright Amazon.com, Inc. or its affiliates. All Rights Reserved.
+#
+# Licensed under the Apache License, Version 2.0 (the "License"). You may not use
+# this file except in compliance with the License. A copy of the License is
+# located at
+#
+#     http://aws.amazon.com/apache2.0/
+#
+# or in the "license" file accompanying this file. This file is distributed on an
+# "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or
+# implied. See the License for the specific language governing permissions and
+# limitations under the License.
+
+# Expected runtime is 20 seconds.
+
+CBMCFLAGS +=
+
+PROOF_UID = s2n_stuffer_reserve_uint24
+HARNESS_ENTRY = $(PROOF_UID)_harness
+HARNESS_FILE = $(HARNESS_ENTRY).c
+
+PROOF_SOURCES += $(PROOFDIR)/$(HARNESS_FILE)
+PROOF_SOURCES += $(PROOF_SOURCE)/cbmc_utils.c
+PROOF_SOURCES += $(PROOF_SOURCE)/make_common_datastructures.c
+PROOF_SOURCES += $(PROOF_STUB)/munlock.c
+PROOF_SOURCES += $(PROOF_STUB)/s2n_calculate_stacktrace.c
+PROOF_SOURCES += $(PROOF_STUB)/sysconf.c
+
+PROJECT_SOURCES += $(SRCDIR)/stuffer/s2n_stuffer.c
+PROJECT_SOURCES += $(SRCDIR)/stuffer/s2n_stuffer_network_order.c
+PROJECT_SOURCES += $(SRCDIR)/utils/s2n_blob.c
+PROJECT_SOURCES += $(SRCDIR)/utils/s2n_ensure.c
+PROJECT_SOURCES += $(SRCDIR)/utils/s2n_mem.c
+PROJECT_SOURCES += $(SRCDIR)/utils/s2n_safety.c
+PROJECT_SOURCES += $(SRCDIR)/utils/s2n_result.c
+
+# We abstract these functions because manual inspection demonstrates they are unreachable.
+REMOVE_FUNCTION_BODY += s2n_blob_slice
+REMOVE_FUNCTION_BODY += s2n_stuffer_wipe
+
+UNWINDSET +=
+
+include ../Makefile.common

--- a/tests/cbmc/proofs/s2n_stuffer_resize/Makefile
+++ b/tests/cbmc/proofs/s2n_stuffer_resize/Makefile
@@ -1,4 +1,3 @@
-# Copyright Amazon.com, Inc. or its affiliates. All Rights Reserved.
 #
 # Licensed under the Apache License, Version 2.0 (the "License"). You may not use
 # this file except in compliance with the License. A copy of the License is

--- a/tests/cbmc/proofs/s2n_stuffer_resize/Makefile.backup
+++ b/tests/cbmc/proofs/s2n_stuffer_resize/Makefile.backup
@@ -1,0 +1,45 @@
+# Copyright Amazon.com, Inc. or its affiliates. All Rights Reserved.
+#
+# Licensed under the Apache License, Version 2.0 (the "License"). You may not use
+# this file except in compliance with the License. A copy of the License is
+# located at
+#
+#     http://aws.amazon.com/apache2.0/
+#
+# or in the "license" file accompanying this file. This file is distributed on an
+# "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or
+# implied. See the License for the specific language governing permissions and
+# limitations under the License.
+
+# Expected runtime is 40 seconds.
+CBMCFLAGS +=
+
+PROOF_UID = s2n_stuffer_resize
+HARNESS_ENTRY = $(PROOF_UID)_harness
+HARNESS_FILE = $(HARNESS_ENTRY).c
+
+PROOF_SOURCES += $(PROOFDIR)/$(HARNESS_FILE)
+
+PROOF_SOURCES += $(PROOF_SOURCE)/cbmc_utils.c
+PROOF_SOURCES += $(PROOF_SOURCE)/make_common_datastructures.c
+PROOF_SOURCES += $(PROOF_STUB)/mlock.c
+PROOF_SOURCES += $(PROOF_STUB)/munlock.c
+PROOF_SOURCES += $(PROOF_STUB)/posix_memalign_override.c
+PROOF_SOURCES += $(PROOF_STUB)/s2n_calculate_stacktrace.c
+PROOF_SOURCES += $(PROOF_STUB)/sysconf.c
+
+PROJECT_SOURCES += $(SRCDIR)/error/s2n_errno.c
+PROJECT_SOURCES += $(SRCDIR)/stuffer/s2n_stuffer.c
+PROJECT_SOURCES += $(SRCDIR)/utils/s2n_blob.c
+PROJECT_SOURCES += $(SRCDIR)/utils/s2n_ensure.c
+PROJECT_SOURCES += $(SRCDIR)/utils/s2n_mem.c
+PROJECT_SOURCES += $(SRCDIR)/utils/s2n_safety.c
+PROJECT_SOURCES += $(SRCDIR)/utils/s2n_result.c
+
+# We abstract these functions because manual inspection demonstrates they are unreachable.
+REMOVE_FUNCTION_BODY += __CPROVER_file_local_s2n_mem_c_s2n_mem_cleanup_impl
+REMOVE_FUNCTION_BODY += s2n_blob_slice
+
+UNWINDSET +=
+
+include ../Makefile.common

--- a/tests/cbmc/proofs/s2n_stuffer_resize_if_empty/Makefile
+++ b/tests/cbmc/proofs/s2n_stuffer_resize_if_empty/Makefile
@@ -1,4 +1,3 @@
-# Copyright Amazon.com, Inc. or its affiliates. All Rights Reserved.
 #
 # Licensed under the Apache License, Version 2.0 (the "License"). You may not use
 # this file except in compliance with the License. A copy of the License is

--- a/tests/cbmc/proofs/s2n_stuffer_resize_if_empty/Makefile.backup
+++ b/tests/cbmc/proofs/s2n_stuffer_resize_if_empty/Makefile.backup
@@ -1,0 +1,43 @@
+# Copyright Amazon.com, Inc. or its affiliates. All Rights Reserved.
+#
+# Licensed under the Apache License, Version 2.0 (the "License"). You may not use
+# this file except in compliance with the License. A copy of the License is
+# located at
+#
+#     http://aws.amazon.com/apache2.0/
+#
+# or in the "license" file accompanying this file. This file is distributed on an
+# "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or
+# implied. See the License for the specific language governing permissions and
+# limitations under the License.
+
+# Expected runtime is 20 seconds.
+
+CBMCFLAGS +=
+
+PROOF_UID = s2n_stuffer_resize_if_empty
+HARNESS_ENTRY = $(PROOF_UID)_harness
+HARNESS_FILE = $(HARNESS_ENTRY).c
+
+PROOF_SOURCES += $(PROOFDIR)/$(HARNESS_FILE)
+PROOF_SOURCES += $(PROOF_SOURCE)/cbmc_utils.c
+PROOF_SOURCES += $(PROOF_SOURCE)/make_common_datastructures.c
+
+PROJECT_SOURCES += $(SRCDIR)/error/s2n_errno.c
+PROJECT_SOURCES += $(SRCDIR)/stuffer/s2n_stuffer.c
+PROJECT_SOURCES += $(SRCDIR)/utils/s2n_blob.c
+PROJECT_SOURCES += $(SRCDIR)/utils/s2n_ensure.c
+PROJECT_SOURCES += $(SRCDIR)/utils/s2n_mem.c
+PROJECT_SOURCES += $(SRCDIR)/utils/s2n_safety.c
+PROJECT_SOURCES += $(SRCDIR)/utils/s2n_result.c
+
+
+# We abstract these functions because manual inspection demonstrates they are unreachable.
+REMOVE_FUNCTION_BODY += s2n_calculate_stacktrace
+REMOVE_FUNCTION_BODY += s2n_blob_slice
+REMOVE_FUNCTION_BODY += s2n_ensure_memcpy_trace
+REMOVE_FUNCTION_BODY += __CPROVER_file_local_s2n_mem_c_s2n_mem_cleanup_impl
+
+UNWINDSET +=
+
+include ../Makefile.common

--- a/tests/cbmc/proofs/s2n_stuffer_rewind_read/Makefile
+++ b/tests/cbmc/proofs/s2n_stuffer_rewind_read/Makefile
@@ -1,4 +1,3 @@
-# Copyright Amazon.com, Inc. or its affiliates. All Rights Reserved.
 #
 # Licensed under the Apache License, Version 2.0 (the "License"). You may not use
 # this file except in compliance with the License. A copy of the License is

--- a/tests/cbmc/proofs/s2n_stuffer_rewind_read/Makefile.backup
+++ b/tests/cbmc/proofs/s2n_stuffer_rewind_read/Makefile.backup
@@ -1,0 +1,32 @@
+# Copyright Amazon.com, Inc. or its affiliates. All Rights Reserved.
+#
+# Licensed under the Apache License, Version 2.0 (the "License"). You may not use
+# this file except in compliance with the License. A copy of the License is
+# located at
+#
+#     http://aws.amazon.com/apache2.0/
+#
+# or in the "license" file accompanying this file. This file is distributed on an
+# "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or
+# implied. See the License for the specific language governing permissions and
+# limitations under the License.
+
+# Expected runtime is 10 seconds.
+
+CBMCFLAGS +=
+
+PROOF_UID = s2n_stuffer_rewind_read
+HARNESS_ENTRY = $(PROOF_UID)_harness
+HARNESS_FILE = $(HARNESS_ENTRY).c
+
+PROOF_SOURCES += $(PROOFDIR)/$(HARNESS_FILE)
+PROOF_SOURCES += $(PROOF_SOURCE)/cbmc_utils.c
+PROOF_SOURCES += $(PROOF_SOURCE)/make_common_datastructures.c
+
+PROJECT_SOURCES += $(SRCDIR)/stuffer/s2n_stuffer.c
+PROJECT_SOURCES += $(SRCDIR)/utils/s2n_blob.c
+PROJECT_SOURCES += $(SRCDIR)/utils/s2n_result.c
+
+UNWINDSET +=
+
+include ../Makefile.common

--- a/tests/cbmc/proofs/s2n_stuffer_rewrite/Makefile
+++ b/tests/cbmc/proofs/s2n_stuffer_rewrite/Makefile
@@ -1,4 +1,3 @@
-# Copyright Amazon.com, Inc. or its affiliates. All Rights Reserved.
 #
 # Licensed under the Apache License, Version 2.0 (the "License"). You may not use
 # this file except in compliance with the License. A copy of the License is

--- a/tests/cbmc/proofs/s2n_stuffer_rewrite/Makefile.backup
+++ b/tests/cbmc/proofs/s2n_stuffer_rewrite/Makefile.backup
@@ -1,0 +1,32 @@
+# Copyright Amazon.com, Inc. or its affiliates. All Rights Reserved.
+#
+# Licensed under the Apache License, Version 2.0 (the "License"). You may not use
+# this file except in compliance with the License. A copy of the License is
+# located at
+#
+#     http://aws.amazon.com/apache2.0/
+#
+# or in the "license" file accompanying this file. This file is distributed on an
+# "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or
+# implied. See the License for the specific language governing permissions and
+# limitations under the License.
+
+# Expected runtime is 10 seconds.
+
+CBMCFLAGS +=
+
+PROOF_UID = s2n_stuffer_rewrite
+HARNESS_ENTRY = $(PROOF_UID)_harness
+HARNESS_FILE = $(HARNESS_ENTRY).c
+
+PROOF_SOURCES += $(PROOFDIR)/$(HARNESS_FILE)
+PROOF_SOURCES += $(PROOF_SOURCE)/cbmc_utils.c
+PROOF_SOURCES += $(PROOF_SOURCE)/make_common_datastructures.c
+
+PROJECT_SOURCES += $(SRCDIR)/stuffer/s2n_stuffer.c
+PROJECT_SOURCES += $(SRCDIR)/utils/s2n_blob.c
+PROJECT_SOURCES += $(SRCDIR)/utils/s2n_result.c
+
+UNWINDSET +=
+
+include ../Makefile.common

--- a/tests/cbmc/proofs/s2n_stuffer_send_to_fd/Makefile
+++ b/tests/cbmc/proofs/s2n_stuffer_send_to_fd/Makefile
@@ -1,4 +1,3 @@
-# Copyright Amazon.com, Inc. or its affiliates. All Rights Reserved.
 #
 # Licensed under the Apache License, Version 2.0 (the "License"). You may not use
 # this file except in compliance with the License. A copy of the License is

--- a/tests/cbmc/proofs/s2n_stuffer_send_to_fd/Makefile.backup
+++ b/tests/cbmc/proofs/s2n_stuffer_send_to_fd/Makefile.backup
@@ -1,0 +1,42 @@
+# Copyright Amazon.com, Inc. or its affiliates. All Rights Reserved.
+#
+# Licensed under the Apache License, Version 2.0 (the "License"). You may not use
+# this file except in compliance with the License. A copy of the License is
+# located at
+#
+#     http://aws.amazon.com/apache2.0/
+#
+# or in the "license" file accompanying this file. This file is distributed on an
+# "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or
+# implied. See the License for the specific language governing permissions and
+# limitations under the License.
+
+# Expected runtime is 30 seconds.
+
+CBMCFLAGS +=
+
+PROOF_UID = s2n_stuffer_send_to_fd
+HARNESS_ENTRY = $(PROOF_UID)_harness
+HARNESS_FILE = $(HARNESS_ENTRY).c
+
+PROOF_SOURCES += $(PROOFDIR)/$(HARNESS_FILE)
+PROOF_SOURCES += $(PROOF_SOURCE)/cbmc_utils.c
+PROOF_SOURCES += $(PROOF_SOURCE)/make_common_datastructures.c
+PROOF_SOURCES += $(PROOF_STUB)/s2n_calculate_stacktrace.c
+PROOF_SOURCES += $(PROOF_STUB)/sysconf.c
+PROOF_SOURCES += $(PROOF_STUB)/write.c
+
+PROJECT_SOURCES += $(SRCDIR)/error/s2n_errno.c
+PROJECT_SOURCES += $(SRCDIR)/stuffer/s2n_stuffer.c
+PROJECT_SOURCES += $(SRCDIR)/stuffer/s2n_stuffer_file.c
+PROJECT_SOURCES += $(SRCDIR)/utils/s2n_blob.c
+PROJECT_SOURCES += $(SRCDIR)/utils/s2n_ensure.c
+PROJECT_SOURCES += $(SRCDIR)/utils/s2n_mem.c
+PROJECT_SOURCES += $(SRCDIR)/utils/s2n_safety.c
+PROJECT_SOURCES += $(SRCDIR)/utils/s2n_result.c
+
+REMOVE_FUNCTION_BODY += __CPROVER_file_local_s2n_mem_c_s2n_mem_cleanup_impl
+
+UNWINDSET += s2n_stuffer_send_to_fd.5:3
+
+include ../Makefile.common

--- a/tests/cbmc/proofs/s2n_stuffer_skip_expected_char/Makefile
+++ b/tests/cbmc/proofs/s2n_stuffer_skip_expected_char/Makefile
@@ -1,4 +1,3 @@
-# Copyright Amazon.com, Inc. or its affiliates. All Rights Reserved.
 #
 # Licensed under the Apache License, Version 2.0 (the "License"). You may not use
 # this file except in compliance with the License. A copy of the License is

--- a/tests/cbmc/proofs/s2n_stuffer_skip_expected_char/Makefile.backup
+++ b/tests/cbmc/proofs/s2n_stuffer_skip_expected_char/Makefile.backup
@@ -1,0 +1,35 @@
+# Copyright Amazon.com, Inc. or its affiliates. All Rights Reserved.
+#
+# Licensed under the Apache License, Version 2.0 (the "License"). You may not use
+# this file except in compliance with the License. A copy of the License is
+# located at
+#
+#     http://aws.amazon.com/apache2.0/
+#
+# or in the "license" file accompanying this file. This file is distributed on an
+# "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or
+# implied. See the License for the specific language governing permissions and
+# limitations under the License.
+
+# Enough to get full coverage with 10 seconds of runtime.
+MAX_BLOB_SIZE = 10
+DEFINES += -DMAX_BLOB_SIZE=$(MAX_BLOB_SIZE)
+
+CBMCFLAGS +=
+
+PROOF_UID = s2n_stuffer_skip_expected_char
+HARNESS_ENTRY = $(PROOF_UID)_harness
+HARNESS_FILE = $(HARNESS_ENTRY).c
+
+PROOF_SOURCES += $(PROOFDIR)/$(HARNESS_FILE)
+PROOF_SOURCES += $(PROOF_SOURCE)/cbmc_utils.c
+PROOF_SOURCES += $(PROOF_SOURCE)/make_common_datastructures.c
+
+PROJECT_SOURCES += $(SRCDIR)/stuffer/s2n_stuffer.c
+PROJECT_SOURCES += $(SRCDIR)/stuffer/s2n_stuffer_text.c
+PROJECT_SOURCES += $(SRCDIR)/utils/s2n_blob.c
+PROJECT_SOURCES += $(SRCDIR)/utils/s2n_result.c
+
+UNWINDSET += s2n_stuffer_skip_expected_char.4:$(call addone,$(MAX_BLOB_SIZE))
+
+include ../Makefile.common

--- a/tests/cbmc/proofs/s2n_stuffer_skip_read/Makefile
+++ b/tests/cbmc/proofs/s2n_stuffer_skip_read/Makefile
@@ -1,4 +1,3 @@
-# Copyright Amazon.com, Inc. or its affiliates. All Rights Reserved.
 #
 # Licensed under the Apache License, Version 2.0 (the "License"). You may not use
 # this file except in compliance with the License. A copy of the License is

--- a/tests/cbmc/proofs/s2n_stuffer_skip_read/Makefile.backup
+++ b/tests/cbmc/proofs/s2n_stuffer_skip_read/Makefile.backup
@@ -1,0 +1,35 @@
+# Copyright Amazon.com, Inc. or its affiliates. All Rights Reserved.
+#
+# Licensed under the Apache License, Version 2.0 (the "License"). You may not use
+# this file except in compliance with the License. A copy of the License is
+# located at
+#
+#     http://aws.amazon.com/apache2.0/
+#
+# or in the "license" file accompanying this file. This file is distributed on an
+# "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or
+# implied. See the License for the specific language governing permissions and
+# limitations under the License.
+
+###########
+#Use the default set of CBMC flags
+CHECKFLAGS +=
+
+PROOF_UID = s2n_stuffer_skip_read
+HARNESS_ENTRY = $(PROOF_UID)_harness
+HARNESS_FILE = $(HARNESS_ENTRY).c
+
+PROOF_SOURCES += $(PROOFDIR)/$(HARNESS_FILE)
+PROOF_SOURCES += $(PROOF_SOURCE)/cbmc_utils.c
+PROOF_SOURCES += $(PROOF_SOURCE)/make_common_datastructures.c
+
+PROJECT_SOURCES += $(SRCDIR)/stuffer/s2n_stuffer.c
+PROJECT_SOURCES += $(SRCDIR)/utils/s2n_blob.c
+PROJECT_SOURCES += $(SRCDIR)/utils/s2n_ensure.c
+PROJECT_SOURCES += $(SRCDIR)/utils/s2n_result.c
+
+#No loops to unwind
+UNWINDSET +=
+###########
+
+include ../Makefile.common

--- a/tests/cbmc/proofs/s2n_stuffer_skip_read_until/Makefile
+++ b/tests/cbmc/proofs/s2n_stuffer_skip_read_until/Makefile
@@ -1,4 +1,3 @@
-# Copyright Amazon.com, Inc. or its affiliates. All Rights Reserved.
 #
 # Licensed under the Apache License, Version 2.0 (the "License"). You may not use
 # this file except in compliance with the License. A copy of the License is

--- a/tests/cbmc/proofs/s2n_stuffer_skip_read_until/Makefile.backup
+++ b/tests/cbmc/proofs/s2n_stuffer_skip_read_until/Makefile.backup
@@ -1,0 +1,45 @@
+# Copyright Amazon.com, Inc. or its affiliates. All Rights Reserved.
+#
+# Licensed under the Apache License, Version 2.0 (the "License"). You may not use
+# this file except in compliance with the License. A copy of the License is
+# located at
+#
+#     http://aws.amazon.com/apache2.0/
+#
+# or in the "license" file accompanying this file. This file is distributed on an
+# "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or
+# implied. See the License for the specific language governing permissions and
+# limitations under the License.
+
+# Enough to get full coverage with 10 seconds of runtime.
+MAX_BLOB_SIZE = 5
+DEFINES += -DMAX_BLOB_SIZE=$(MAX_BLOB_SIZE)
+
+MAX_STRING_LEN = 5
+DEFINES += -DMAX_STRING_LEN=$(MAX_STRING_LEN)
+
+CBMCFLAGS +=
+
+PROOF_UID = s2n_stuffer_skip_read_until
+HARNESS_ENTRY = $(PROOF_UID)_harness
+HARNESS_FILE = $(HARNESS_ENTRY).c
+
+PROOF_SOURCES += $(PROOFDIR)/$(HARNESS_FILE)
+PROOF_SOURCES += $(PROOF_SOURCE)/cbmc_utils.c
+PROOF_SOURCES += $(PROOF_SOURCE)/make_common_datastructures.c
+PROOF_SOURCES += $(PROOF_STUB)/posix_memalign_override.c
+PROOF_SOURCES += $(PROOF_STUB)/s2n_calculate_stacktrace.c
+
+PROJECT_SOURCES += $(SRCDIR)/stuffer/s2n_stuffer.c
+PROJECT_SOURCES += $(SRCDIR)/stuffer/s2n_stuffer_network_order.c
+PROJECT_SOURCES += $(SRCDIR)/stuffer/s2n_stuffer_text.c
+PROJECT_SOURCES += $(SRCDIR)/utils/s2n_blob.c
+PROJECT_SOURCES += $(SRCDIR)/utils/s2n_ensure.c
+PROJECT_SOURCES += $(SRCDIR)/utils/s2n_result.c
+
+UNWINDSET += s2n_stuffer_skip_read_until.10:$(call addone,$(MAX_BLOB_SIZE))
+UNWINDSET += s2n_stuffer_skip_to_char.1:$(call addone,$(MAX_BLOB_SIZE))
+UNWINDSET += strlen.0:$(call addone,$(MAX_STRING_LEN))
+UNWINDSET += strncmp.0:$(call addone,$(MAX_STRING_LEN))
+
+include ../Makefile.common

--- a/tests/cbmc/proofs/s2n_stuffer_skip_to_char/Makefile
+++ b/tests/cbmc/proofs/s2n_stuffer_skip_to_char/Makefile
@@ -1,4 +1,3 @@
-# Copyright Amazon.com, Inc. or its affiliates. All Rights Reserved.
 #
 # Licensed under the Apache License, Version 2.0 (the "License"). You may not use
 # this file except in compliance with the License. A copy of the License is

--- a/tests/cbmc/proofs/s2n_stuffer_skip_to_char/Makefile.backup
+++ b/tests/cbmc/proofs/s2n_stuffer_skip_to_char/Makefile.backup
@@ -1,0 +1,35 @@
+# Copyright Amazon.com, Inc. or its affiliates. All Rights Reserved.
+#
+# Licensed under the Apache License, Version 2.0 (the "License"). You may not use
+# this file except in compliance with the License. A copy of the License is
+# located at
+#
+#     http://aws.amazon.com/apache2.0/
+#
+# or in the "license" file accompanying this file. This file is distributed on an
+# "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or
+# implied. See the License for the specific language governing permissions and
+# limitations under the License.
+
+# Enough to get full coverage with 40 seconds of runtime.
+MAX_BLOB_SIZE = 10
+DEFINES += -DMAX_BLOB_SIZE=$(MAX_BLOB_SIZE)
+
+PROOF_UID = s2n_stuffer_skip_to_char
+HARNESS_ENTRY = $(PROOF_UID)_harness
+HARNESS_FILE = $(HARNESS_ENTRY).c
+
+PROOF_SOURCES += $(PROOFDIR)/$(HARNESS_FILE)
+PROOF_SOURCES += $(PROOF_SOURCE)/cbmc_utils.c
+PROOF_SOURCES += $(PROOF_SOURCE)/make_common_datastructures.c
+
+PROJECT_SOURCES += $(SRCDIR)/stuffer/s2n_stuffer.c
+PROJECT_SOURCES += $(SRCDIR)/stuffer/s2n_stuffer_text.c
+PROJECT_SOURCES += $(SRCDIR)/stuffer/s2n_stuffer_network_order.c
+PROJECT_SOURCES += $(SRCDIR)/utils/s2n_blob.c
+PROJECT_SOURCES += $(SRCDIR)/utils/s2n_ensure.c
+PROJECT_SOURCES += $(SRCDIR)/utils/s2n_result.c
+
+UNWINDSET += s2n_stuffer_skip_to_char.1:$(call addone,$(MAX_BLOB_SIZE))
+
+include ../Makefile.common

--- a/tests/cbmc/proofs/s2n_stuffer_skip_whitespace/Makefile
+++ b/tests/cbmc/proofs/s2n_stuffer_skip_whitespace/Makefile
@@ -1,4 +1,3 @@
-# Copyright Amazon.com, Inc. or its affiliates. All Rights Reserved.
 #
 # Licensed under the Apache License, Version 2.0 (the "License"). You may not use
 # this file except in compliance with the License. A copy of the License is

--- a/tests/cbmc/proofs/s2n_stuffer_skip_whitespace/Makefile.backup
+++ b/tests/cbmc/proofs/s2n_stuffer_skip_whitespace/Makefile.backup
@@ -1,0 +1,41 @@
+# Copyright Amazon.com, Inc. or its affiliates. All Rights Reserved.
+#
+# Licensed under the Apache License, Version 2.0 (the "License"). You may not use
+# this file except in compliance with the License. A copy of the License is
+# located at
+#
+#     http://aws.amazon.com/apache2.0/
+#
+# or in the "license" file accompanying this file. This file is distributed on an
+# "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or
+# implied. See the License for the specific language governing permissions and
+# limitations under the License.
+
+# Enough to get full coverage with 4 minutes of runtime.
+MAX_BLOB_SIZE = 2
+DEFINES += -DMAX_BLOB_SIZE=$(MAX_BLOB_SIZE)
+
+CHECKFLAGS +=
+
+PROOF_UID = s2n_stuffer_skip_whitespace
+HARNESS_ENTRY = $(PROOF_UID)_harness
+HARNESS_FILE = $(HARNESS_ENTRY).c
+
+PROOF_SOURCES += $(PROOFDIR)/$(HARNESS_FILE)
+PROOF_SOURCES += $(PROOF_SOURCE)/cbmc_utils.c
+PROOF_SOURCES += $(PROOF_SOURCE)/make_common_datastructures.c
+
+PROJECT_SOURCES += $(SRCDIR)/stuffer/s2n_stuffer.c
+PROJECT_SOURCES += $(SRCDIR)/stuffer/s2n_stuffer_text.c
+PROJECT_SOURCES += $(SRCDIR)/utils/s2n_blob.c
+PROJECT_SOURCES += $(SRCDIR)/utils/s2n_result.c
+
+UNWINDSET += s2n_stuffer_skip_whitespace.0:$(call addone,$(MAX_BLOB_SIZE))
+UNWINDSET += s2n_stuffer_skip_whitespace.1:$(call addone,$(MAX_BLOB_SIZE))
+UNWINDSET += s2n_stuffer_skip_whitespace.2:$(call addone,$(MAX_BLOB_SIZE))
+UNWINDSET += s2n_stuffer_skip_whitespace.3:$(call addone,$(MAX_BLOB_SIZE))
+UNWINDSET += s2n_stuffer_skip_whitespace.4:$(call addone,$(MAX_BLOB_SIZE))
+UNWINDSET += s2n_stuffer_skip_whitespace.5:$(call addone,$(MAX_BLOB_SIZE))
+UNWINDSET += s2n_stuffer_skip_whitespace.6:$(call addone,$(MAX_BLOB_SIZE))
+
+include ../Makefile.common

--- a/tests/cbmc/proofs/s2n_stuffer_skip_write/Makefile
+++ b/tests/cbmc/proofs/s2n_stuffer_skip_write/Makefile
@@ -1,4 +1,3 @@
-# Copyright Amazon.com, Inc. or its affiliates. All Rights Reserved.
 #
 # Licensed under the Apache License, Version 2.0 (the "License"). You may not use
 # this file except in compliance with the License. A copy of the License is

--- a/tests/cbmc/proofs/s2n_stuffer_skip_write/Makefile.backup
+++ b/tests/cbmc/proofs/s2n_stuffer_skip_write/Makefile.backup
@@ -1,0 +1,45 @@
+# Copyright Amazon.com, Inc. or its affiliates. All Rights Reserved.
+#
+# Licensed under the Apache License, Version 2.0 (the "License"). You may not use
+# this file except in compliance with the License. A copy of the License is
+# located at
+#
+#     http://aws.amazon.com/apache2.0/
+#
+# or in the "license" file accompanying this file. This file is distributed on an
+# "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or
+# implied. See the License for the specific language governing permissions and
+# limitations under the License.
+
+# Expected runtime is 20 seconds.
+
+CBMCFLAGS +=
+
+PROOF_UID = s2n_stuffer_skip_write
+HARNESS_ENTRY = $(PROOF_UID)_harness
+HARNESS_FILE = $(HARNESS_ENTRY).c
+
+PROOF_SOURCES += $(PROOFDIR)/$(HARNESS_FILE)
+PROOF_SOURCES += $(PROOF_SOURCE)/cbmc_utils.c
+PROOF_SOURCES += $(PROOF_SOURCE)/make_common_datastructures.c
+PROOF_SOURCES += $(PROOF_STUB)/mlock.c
+PROOF_SOURCES += $(PROOF_STUB)/munlock.c
+PROOF_SOURCES += $(PROOF_STUB)/posix_memalign_override.c
+PROOF_SOURCES += $(PROOF_STUB)/s2n_calculate_stacktrace.c
+PROOF_SOURCES += $(PROOF_STUB)/sysconf.c
+
+PROJECT_SOURCES += $(SRCDIR)/stuffer/s2n_stuffer.c
+PROJECT_SOURCES += $(SRCDIR)/utils/s2n_blob.c
+PROJECT_SOURCES += $(SRCDIR)/utils/s2n_ensure.c
+PROJECT_SOURCES += $(SRCDIR)/utils/s2n_mem.c
+PROJECT_SOURCES += $(SRCDIR)/utils/s2n_safety.c
+PROJECT_SOURCES += $(SRCDIR)/utils/s2n_result.c
+
+# We abstract these functions because manual inspection demonstrates they are unreachable.
+REMOVE_FUNCTION_BODY += __CPROVER_file_local_s2n_mem_c_s2n_mem_cleanup_impl
+REMOVE_FUNCTION_BODY += s2n_blob_slice
+REMOVE_FUNCTION_BODY += s2n_stuffer_wipe
+
+UNWINDSET +=
+
+include ../Makefile.common

--- a/tests/cbmc/proofs/s2n_stuffer_wipe/Makefile
+++ b/tests/cbmc/proofs/s2n_stuffer_wipe/Makefile
@@ -1,4 +1,3 @@
-# Copyright Amazon.com, Inc. or its affiliates. All Rights Reserved.
 #
 # Licensed under the Apache License, Version 2.0 (the "License"). You may not use
 # this file except in compliance with the License. A copy of the License is

--- a/tests/cbmc/proofs/s2n_stuffer_wipe/Makefile.backup
+++ b/tests/cbmc/proofs/s2n_stuffer_wipe/Makefile.backup
@@ -1,0 +1,34 @@
+# Copyright Amazon.com, Inc. or its affiliates. All Rights Reserved.
+#
+# Licensed under the Apache License, Version 2.0 (the "License"). You may not use
+# this file except in compliance with the License. A copy of the License is
+# located at
+#
+#     http://aws.amazon.com/apache2.0/
+#
+# or in the "license" file accompanying this file. This file is distributed on an
+# "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or
+# implied. See the License for the specific language governing permissions and
+# limitations under the License.
+
+###########
+#Use the default set of CBMC flags
+CHECKFLAGS +=
+
+PROOF_UID = s2n_stuffer_wipe
+HARNESS_ENTRY = $(PROOF_UID)_harness
+HARNESS_FILE = $(HARNESS_ENTRY).c
+
+PROOF_SOURCES += $(PROOFDIR)/$(HARNESS_FILE)
+PROOF_SOURCES += $(PROOF_SOURCE)/make_common_datastructures.c
+
+PROJECT_SOURCES += $(SRCDIR)/stuffer/s2n_stuffer.c
+PROJECT_SOURCES += $(SRCDIR)/utils/s2n_blob.c
+PROJECT_SOURCES += $(SRCDIR)/utils/s2n_ensure.c
+PROJECT_SOURCES += $(SRCDIR)/utils/s2n_result.c
+
+#No loops to unwind
+UNWINDSET +=
+###########
+
+include ../Makefile.common

--- a/tests/cbmc/proofs/s2n_stuffer_wipe_n/Makefile
+++ b/tests/cbmc/proofs/s2n_stuffer_wipe_n/Makefile
@@ -1,4 +1,3 @@
-# Copyright Amazon.com, Inc. or its affiliates. All Rights Reserved.
 #
 # Licensed under the Apache License, Version 2.0 (the "License"). You may not use
 # this file except in compliance with the License. A copy of the License is

--- a/tests/cbmc/proofs/s2n_stuffer_wipe_n/Makefile.backup
+++ b/tests/cbmc/proofs/s2n_stuffer_wipe_n/Makefile.backup
@@ -1,0 +1,35 @@
+# Copyright Amazon.com, Inc. or its affiliates. All Rights Reserved.
+#
+# Licensed under the Apache License, Version 2.0 (the "License"). You may not use
+# this file except in compliance with the License. A copy of the License is
+# located at
+#
+#     http://aws.amazon.com/apache2.0/
+#
+# or in the "license" file accompanying this file. This file is distributed on an
+# "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or
+# implied. See the License for the specific language governing permissions and
+# limitations under the License.
+
+###########
+#Use the default set of CBMC flags
+CHECKFLAGS +=
+
+PROOF_UID = s2n_stuffer_wipe_n
+HARNESS_ENTRY = $(PROOF_UID)_harness
+HARNESS_FILE = $(HARNESS_ENTRY).c
+
+PROOF_SOURCES += $(PROOFDIR)/$(HARNESS_FILE)
+PROOF_SOURCES += $(PROOF_SOURCE)/make_common_datastructures.c
+PROOF_SOURCES += $(PROOF_SOURCE)/cbmc_utils.c
+
+PROJECT_SOURCES += $(SRCDIR)/stuffer/s2n_stuffer.c
+PROJECT_SOURCES += $(SRCDIR)/utils/s2n_blob.c
+PROJECT_SOURCES += $(SRCDIR)/utils/s2n_ensure.c
+PROJECT_SOURCES += $(SRCDIR)/utils/s2n_result.c
+
+#No loops to unwind
+UNWINDSET +=
+###########
+
+include ../Makefile.common

--- a/tests/cbmc/proofs/s2n_stuffer_write/Makefile
+++ b/tests/cbmc/proofs/s2n_stuffer_write/Makefile
@@ -1,4 +1,3 @@
-# Copyright Amazon.com, Inc. or its affiliates. All Rights Reserved.
 #
 # Licensed under the Apache License, Version 2.0 (the "License"). You may not use
 # this file except in compliance with the License. A copy of the License is

--- a/tests/cbmc/proofs/s2n_stuffer_write/Makefile.backup
+++ b/tests/cbmc/proofs/s2n_stuffer_write/Makefile.backup
@@ -1,0 +1,40 @@
+# Copyright Amazon.com, Inc. or its affiliates. All Rights Reserved.
+#
+# Licensed under the Apache License, Version 2.0 (the "License"). You may not use
+# this file except in compliance with the License. A copy of the License is
+# located at
+#
+#     http://aws.amazon.com/apache2.0/
+#
+# or in the "license" file accompanying this file. This file is distributed on an
+# "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or
+# implied. See the License for the specific language governing permissions and
+# limitations under the License.
+
+# Expected runtime is 2 minutes.
+
+CBMCFLAGS +=
+
+PROOF_UID = s2n_stuffer_write
+HARNESS_ENTRY = $(PROOF_UID)_harness
+HARNESS_FILE = $(HARNESS_ENTRY).c
+
+PROOF_SOURCES += $(PROOFDIR)/$(HARNESS_FILE)
+PROOF_SOURCES += $(PROOF_SOURCE)/cbmc_utils.c
+PROOF_SOURCES += $(PROOF_SOURCE)/make_common_datastructures.c
+
+PROJECT_SOURCES += $(SRCDIR)/stuffer/s2n_stuffer.c
+PROJECT_SOURCES += $(SRCDIR)/utils/s2n_blob.c
+PROJECT_SOURCES += $(SRCDIR)/utils/s2n_ensure.c
+PROJECT_SOURCES += $(SRCDIR)/utils/s2n_mem.c
+PROJECT_SOURCES += $(SRCDIR)/utils/s2n_safety.c
+PROJECT_SOURCES += $(SRCDIR)/utils/s2n_result.c
+
+# We abstract these functions because manual inspection demonstrates they are unreachable.
+REMOVE_FUNCTION_BODY += s2n_blob_slice
+REMOVE_FUNCTION_BODY += __CPROVER_file_local_s2n_mem_c_s2n_mem_cleanup_impl
+REMOVE_FUNCTION_BODY += s2n_stuffer_wipe
+
+UNWINDSET +=
+
+include ../Makefile.common

--- a/tests/cbmc/proofs/s2n_stuffer_write_base64/Makefile
+++ b/tests/cbmc/proofs/s2n_stuffer_write_base64/Makefile
@@ -1,4 +1,3 @@
-# Copyright Amazon.com, Inc. or its affiliates. All Rights Reserved.
 #
 # Licensed under the Apache License, Version 2.0 (the "License"). You may not use
 # this file except in compliance with the License. A copy of the License is

--- a/tests/cbmc/proofs/s2n_stuffer_write_base64/Makefile.backup
+++ b/tests/cbmc/proofs/s2n_stuffer_write_base64/Makefile.backup
@@ -1,0 +1,49 @@
+# Copyright Amazon.com, Inc. or its affiliates. All Rights Reserved.
+#
+# Licensed under the Apache License, Version 2.0 (the "License"). You may not use
+# this file except in compliance with the License. A copy of the License is
+# located at
+#
+#     http://aws.amazon.com/apache2.0/
+#
+# or in the "license" file accompanying this file. This file is distributed on an
+# "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or
+# implied. See the License for the specific language governing permissions and
+# limitations under the License.
+
+# Enough to get full coverage with 11 minutes of runtime.
+MAX_BLOB_SIZE = 4
+DEFINES += -DMAX_BLOB_SIZE=$(MAX_BLOB_SIZE)
+
+CBMCFLAGS +=
+
+PROOF_UID = s2n_stuffer_write_base64
+HARNESS_ENTRY = $(PROOF_UID)_harness
+HARNESS_FILE = $(HARNESS_ENTRY).c
+
+PROOF_SOURCES += $(PROOFDIR)/$(HARNESS_FILE)
+PROOF_SOURCES += $(PROOF_SOURCE)/cbmc_utils.c
+PROOF_SOURCES += $(PROOF_SOURCE)/make_common_datastructures.c
+PROOF_SOURCES += $(PROOF_STUB)/mlock.c
+PROOF_SOURCES += $(PROOF_STUB)/munlock.c
+PROOF_SOURCES += $(PROOF_STUB)/posix_memalign_override.c
+PROOF_SOURCES += $(PROOF_STUB)/s2n_calculate_stacktrace.c
+PROOF_SOURCES += $(PROOF_STUB)/sysconf.c
+
+PROJECT_SOURCES += $(SRCDIR)/stuffer/s2n_stuffer.c
+PROJECT_SOURCES += $(SRCDIR)/stuffer/s2n_stuffer_base64.c
+PROJECT_SOURCES += $(SRCDIR)/stuffer/s2n_stuffer_network_order.c
+PROJECT_SOURCES += $(SRCDIR)/utils/s2n_blob.c
+PROJECT_SOURCES += $(SRCDIR)/utils/s2n_ensure.c
+PROJECT_SOURCES += $(SRCDIR)/utils/s2n_safety.c
+PROJECT_SOURCES += $(SRCDIR)/utils/s2n_mem.c
+PROJECT_SOURCES += $(SRCDIR)/utils/s2n_result.c
+
+# We abstract these functions because manual inspection demonstrates they are unreachable.
+REMOVE_FUNCTION_BODY += __CPROVER_file_local_s2n_mem_c_s2n_mem_cleanup_impl
+REMOVE_FUNCTION_BODY += s2n_blob_slice
+REMOVE_FUNCTION_BODY += s2n_stuffer_wipe
+
+UNWINDSET += s2n_stuffer_write_base64.12:$(MAX_BLOB_SIZE)
+
+include ../Makefile.common

--- a/tests/cbmc/proofs/s2n_stuffer_write_bytes/Makefile
+++ b/tests/cbmc/proofs/s2n_stuffer_write_bytes/Makefile
@@ -1,4 +1,3 @@
-# Copyright Amazon.com, Inc. or its affiliates. All Rights Reserved.
 #
 # Licensed under the Apache License, Version 2.0 (the "License"). You may not use
 # this file except in compliance with the License. A copy of the License is

--- a/tests/cbmc/proofs/s2n_stuffer_write_bytes/Makefile.backup
+++ b/tests/cbmc/proofs/s2n_stuffer_write_bytes/Makefile.backup
@@ -1,0 +1,40 @@
+# Copyright Amazon.com, Inc. or its affiliates. All Rights Reserved.
+#
+# Licensed under the Apache License, Version 2.0 (the "License"). You may not use
+# this file except in compliance with the License. A copy of the License is
+# located at
+#
+#     http://aws.amazon.com/apache2.0/
+#
+# or in the "license" file accompanying this file. This file is distributed on an
+# "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or
+# implied. See the License for the specific language governing permissions and
+# limitations under the License.
+
+# Expected runtime is 60 seconds.
+
+CBMCFLAGS +=
+
+PROOF_UID = s2n_stuffer_write_bytes
+HARNESS_ENTRY = $(PROOF_UID)_harness
+HARNESS_FILE = $(HARNESS_ENTRY).c
+
+PROOF_SOURCES += $(PROOFDIR)/$(HARNESS_FILE)
+PROOF_SOURCES += $(PROOF_SOURCE)/cbmc_utils.c
+PROOF_SOURCES += $(PROOF_SOURCE)/make_common_datastructures.c
+
+PROJECT_SOURCES += $(SRCDIR)/stuffer/s2n_stuffer.c
+PROJECT_SOURCES += $(SRCDIR)/utils/s2n_blob.c
+PROJECT_SOURCES += $(SRCDIR)/utils/s2n_ensure.c
+PROJECT_SOURCES += $(SRCDIR)/utils/s2n_mem.c
+PROJECT_SOURCES += $(SRCDIR)/utils/s2n_safety.c
+PROJECT_SOURCES += $(SRCDIR)/utils/s2n_result.c
+
+# We abstract these functions because manual inspection demonstrates they are unreachable.
+REMOVE_FUNCTION_BODY += s2n_blob_slice
+REMOVE_FUNCTION_BODY += __CPROVER_file_local_s2n_mem_c_s2n_mem_cleanup_impl
+REMOVE_FUNCTION_BODY += s2n_stuffer_wipe
+
+UNWINDSET +=
+
+include ../Makefile.common

--- a/tests/cbmc/proofs/s2n_stuffer_write_network_order/Makefile
+++ b/tests/cbmc/proofs/s2n_stuffer_write_network_order/Makefile
@@ -1,4 +1,3 @@
-# Copyright Amazon.com, Inc. or its affiliates. All Rights Reserved.
 #
 # Licensed under the Apache License, Version 2.0 (the "License"). You may not use
 # this file except in compliance with the License. A copy of the License is

--- a/tests/cbmc/proofs/s2n_stuffer_write_network_order/Makefile.backup
+++ b/tests/cbmc/proofs/s2n_stuffer_write_network_order/Makefile.backup
@@ -1,0 +1,44 @@
+# Copyright Amazon.com, Inc. or its affiliates. All Rights Reserved.
+#
+# Licensed under the Apache License, Version 2.0 (the "License"). You may not use
+# this file except in compliance with the License. A copy of the License is
+# located at
+#
+#     http://aws.amazon.com/apache2.0/
+#
+# or in the "license" file accompanying this file. This file is distributed on an
+# "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or
+# implied. See the License for the specific language governing permissions and
+# limitations under the License.
+
+# Expected runtime is 2 minutes.
+CBMCFLAGS +=
+
+PROOF_UID = s2n_stuffer_write_network_order
+HARNESS_ENTRY = $(PROOF_UID)_harness
+HARNESS_FILE = $(HARNESS_ENTRY).c
+
+PROOF_SOURCES += $(PROOFDIR)/$(HARNESS_FILE)
+PROOF_SOURCES += $(PROOF_SOURCE)/cbmc_utils.c
+PROOF_SOURCES += $(PROOF_SOURCE)/make_common_datastructures.c
+PROOF_SOURCES += $(PROOF_STUB)/munlock.c
+PROOF_SOURCES += $(PROOF_STUB)/s2n_calculate_stacktrace.c
+PROOF_SOURCES += $(PROOF_STUB)/sysconf.c
+
+PROJECT_SOURCES += $(SRCDIR)/stuffer/s2n_stuffer.c
+PROJECT_SOURCES += $(SRCDIR)/stuffer/s2n_stuffer_network_order.c
+PROJECT_SOURCES += $(SRCDIR)/utils/s2n_blob.c
+PROJECT_SOURCES += $(SRCDIR)/utils/s2n_ensure.c
+PROJECT_SOURCES += $(SRCDIR)/utils/s2n_mem.c
+PROJECT_SOURCES += $(SRCDIR)/utils/s2n_safety.c
+PROJECT_SOURCES += $(SRCDIR)/utils/s2n_result.c
+
+# We abstract these functions because manual inspection demonstrates they are unreachable.
+REMOVE_FUNCTION_BODY += __CPROVER_file_local_s2n_mem_c_s2n_mem_cleanup_impl
+REMOVE_FUNCTION_BODY += s2n_blob_slice
+REMOVE_FUNCTION_BODY += s2n_stuffer_wipe
+
+UNWINDSET += s2n_stuffer_write_network_order.4:9
+UNWINDSET += s2n_stuffer_write_network_order_harness.0:9
+
+include ../Makefile.common

--- a/tests/cbmc/proofs/s2n_stuffer_write_reservation/Makefile
+++ b/tests/cbmc/proofs/s2n_stuffer_write_reservation/Makefile
@@ -1,4 +1,3 @@
-# Copyright Amazon.com, Inc. or its affiliates. All Rights Reserved.
 #
 # Licensed under the Apache License, Version 2.0 (the "License"). You may not use
 # this file except in compliance with the License. A copy of the License is

--- a/tests/cbmc/proofs/s2n_stuffer_write_reservation/Makefile.backup
+++ b/tests/cbmc/proofs/s2n_stuffer_write_reservation/Makefile.backup
@@ -1,0 +1,60 @@
+# Copyright Amazon.com, Inc. or its affiliates. All Rights Reserved.
+#
+# Licensed under the Apache License, Version 2.0 (the "License"). You may not use
+# this file except in compliance with the License. A copy of the License is
+# located at
+#
+#     http://aws.amazon.com/apache2.0/
+#
+# or in the "license" file accompanying this file. This file is distributed on an
+# "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or
+# implied. See the License for the specific language governing permissions and
+# limitations under the License.
+
+# Expected runtime is 29 minutes.
+DEFINES += -DMADV_DONTDUMP=1
+
+# This the the maximum number of iterations to unroll
+# the loop in s2n_stuffer_write_network_order
+MAX_WRITE_NETWORK_ORDER = 9
+
+CBMCFLAGS +=
+
+PROOF_UID = s2n_stuffer_write_reservation
+HARNESS_ENTRY = $(PROOF_UID)_harness
+HARNESS_FILE = $(HARNESS_ENTRY).c
+
+PROOF_SOURCES += $(PROOFDIR)/$(HARNESS_FILE)
+PROOF_SOURCES += $(PROOF_SOURCE)/cbmc_utils.c
+PROOF_SOURCES += $(PROOF_SOURCE)/make_common_datastructures.c
+PROOF_SOURCES += $(PROOF_STUB)/madvise.c
+PROOF_SOURCES += $(PROOF_STUB)/mlock.c
+PROOF_SOURCES += $(PROOF_STUB)/munlock.c
+PROOF_SOURCES += $(PROOF_STUB)/posix_memalign_override.c
+PROOF_SOURCES += $(PROOF_STUB)/s2n_calculate_stacktrace.c
+PROOF_SOURCES += $(PROOF_STUB)/sysconf.c
+
+PROJECT_SOURCES += $(SRCDIR)/stuffer/s2n_stuffer.c
+PROJECT_SOURCES += $(SRCDIR)/stuffer/s2n_stuffer_network_order.c
+PROJECT_SOURCES += $(SRCDIR)/utils/s2n_blob.c
+PROJECT_SOURCES += $(SRCDIR)/utils/s2n_ensure.c
+PROJECT_SOURCES += $(SRCDIR)/utils/s2n_mem.c
+PROJECT_SOURCES += $(SRCDIR)/utils/s2n_safety.c
+PROJECT_SOURCES += $(SRCDIR)/utils/s2n_result.c
+
+# We abstract these functions because manual inspection demonstrates they are unreachable.
+REMOVE_FUNCTION_BODY += s2n_blob_slice
+REMOVE_FUNCTION_BODY += s2n_stuffer_wipe
+REMOVE_FUNCTION_BODY += s2n_stuffer_wipe_n
+REMOVE_FUNCTION_BODY += __CPROVER_file_local_s2n_mem_c_s2n_mem_cleanup_impl
+
+UNWINDSET += s2n_stuffer_write_network_order.0:$(MAX_WRITE_NETWORK_ORDER)
+UNWINDSET += s2n_stuffer_write_network_order.1:$(MAX_WRITE_NETWORK_ORDER)
+UNWINDSET += s2n_stuffer_write_network_order.2:$(MAX_WRITE_NETWORK_ORDER)
+UNWINDSET += s2n_stuffer_write_network_order.3:$(MAX_WRITE_NETWORK_ORDER)
+UNWINDSET += s2n_stuffer_write_network_order.4:$(MAX_WRITE_NETWORK_ORDER)
+UNWINDSET += s2n_stuffer_write_network_order.5:$(MAX_WRITE_NETWORK_ORDER)
+UNWINDSET += s2n_stuffer_write_network_order.6:$(MAX_WRITE_NETWORK_ORDER)
+UNWINDSET += s2n_stuffer_write_network_order.7:$(MAX_WRITE_NETWORK_ORDER)
+
+include ../Makefile.common

--- a/tests/cbmc/proofs/s2n_stuffer_write_uint16/Makefile
+++ b/tests/cbmc/proofs/s2n_stuffer_write_uint16/Makefile
@@ -1,4 +1,3 @@
-# Copyright Amazon.com, Inc. or its affiliates. All Rights Reserved.
 #
 # Licensed under the Apache License, Version 2.0 (the "License"). You may not use
 # this file except in compliance with the License. A copy of the License is

--- a/tests/cbmc/proofs/s2n_stuffer_write_uint16/Makefile.backup
+++ b/tests/cbmc/proofs/s2n_stuffer_write_uint16/Makefile.backup
@@ -1,0 +1,41 @@
+# Copyright Amazon.com, Inc. or its affiliates. All Rights Reserved.
+#
+# Licensed under the Apache License, Version 2.0 (the "License"). You may not use
+# this file except in compliance with the License. A copy of the License is
+# located at
+#
+#     http://aws.amazon.com/apache2.0/
+#
+# or in the "license" file accompanying this file. This file is distributed on an
+# "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or
+# implied. See the License for the specific language governing permissions and
+# limitations under the License.
+
+# Expected runtime is 30 seconds.
+SIZEOF_UINT16 = 2
+
+CBMCFLAGS +=
+
+PROOF_UID = s2n_stuffer_write_uint16
+HARNESS_ENTRY = $(PROOF_UID)_harness
+HARNESS_FILE = $(HARNESS_ENTRY).c
+
+PROOF_SOURCES += $(PROOFDIR)/$(HARNESS_FILE)
+PROOF_SOURCES += $(PROOF_SOURCE)/cbmc_utils.c
+PROOF_SOURCES += $(PROOF_SOURCE)/make_common_datastructures.c
+
+PROJECT_SOURCES += $(SRCDIR)/stuffer/s2n_stuffer.c
+PROJECT_SOURCES += $(SRCDIR)/stuffer/s2n_stuffer_network_order.c
+PROJECT_SOURCES += $(SRCDIR)/utils/s2n_blob.c
+PROJECT_SOURCES += $(SRCDIR)/utils/s2n_ensure.c
+PROJECT_SOURCES += $(SRCDIR)/utils/s2n_mem.c
+PROJECT_SOURCES += $(SRCDIR)/utils/s2n_safety.c
+PROJECT_SOURCES += $(SRCDIR)/utils/s2n_result.c
+
+# We abstract these functions because manual inspection demonstrates they are unreachable.
+REMOVE_FUNCTION_BODY += s2n_blob_slice
+REMOVE_FUNCTION_BODY += s2n_stuffer_wipe
+
+UNWINDSET += s2n_stuffer_write_network_order.4:$(shell echo $$((1 + $(SIZEOF_UINT16))))
+
+include ../Makefile.common

--- a/tests/cbmc/proofs/s2n_stuffer_write_uint24/Makefile
+++ b/tests/cbmc/proofs/s2n_stuffer_write_uint24/Makefile
@@ -1,4 +1,3 @@
-# Copyright Amazon.com, Inc. or its affiliates. All Rights Reserved.
 #
 # Licensed under the Apache License, Version 2.0 (the "License"). You may not use
 # this file except in compliance with the License. A copy of the License is

--- a/tests/cbmc/proofs/s2n_stuffer_write_uint24/Makefile.backup
+++ b/tests/cbmc/proofs/s2n_stuffer_write_uint24/Makefile.backup
@@ -1,0 +1,41 @@
+# Copyright Amazon.com, Inc. or its affiliates. All Rights Reserved.
+#
+# Licensed under the Apache License, Version 2.0 (the "License"). You may not use
+# this file except in compliance with the License. A copy of the License is
+# located at
+#
+#     http://aws.amazon.com/apache2.0/
+#
+# or in the "license" file accompanying this file. This file is distributed on an
+# "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or
+# implied. See the License for the specific language governing permissions and
+# limitations under the License.
+
+# Expected runtime is 50 seconds.
+SIZEOF_UINT24 = 3
+
+CBMCFLAGS +=
+
+PROOF_UID = s2n_stuffer_write_uint24
+HARNESS_ENTRY = $(PROOF_UID)_harness
+HARNESS_FILE = $(HARNESS_ENTRY).c
+
+PROOF_SOURCES += $(PROOFDIR)/$(HARNESS_FILE)
+PROOF_SOURCES += $(PROOF_SOURCE)/cbmc_utils.c
+PROOF_SOURCES += $(PROOF_SOURCE)/make_common_datastructures.c
+
+PROJECT_SOURCES += $(SRCDIR)/stuffer/s2n_stuffer.c
+PROJECT_SOURCES += $(SRCDIR)/stuffer/s2n_stuffer_network_order.c
+PROJECT_SOURCES += $(SRCDIR)/utils/s2n_blob.c
+PROJECT_SOURCES += $(SRCDIR)/utils/s2n_ensure.c
+PROJECT_SOURCES += $(SRCDIR)/utils/s2n_mem.c
+PROJECT_SOURCES += $(SRCDIR)/utils/s2n_safety.c
+PROJECT_SOURCES += $(SRCDIR)/utils/s2n_result.c
+
+# We abstract these functions because manual inspection demonstrates they are unreachable.
+REMOVE_FUNCTION_BODY += s2n_blob_slice
+REMOVE_FUNCTION_BODY += s2n_stuffer_wipe
+
+UNWINDSET += s2n_stuffer_write_network_order.4:$(shell echo $$((1 + $(SIZEOF_UINT24))))
+
+include ../Makefile.common

--- a/tests/cbmc/proofs/s2n_stuffer_write_uint32/Makefile
+++ b/tests/cbmc/proofs/s2n_stuffer_write_uint32/Makefile
@@ -1,4 +1,3 @@
-# Copyright Amazon.com, Inc. or its affiliates. All Rights Reserved.
 #
 # Licensed under the Apache License, Version 2.0 (the "License"). You may not use
 # this file except in compliance with the License. A copy of the License is

--- a/tests/cbmc/proofs/s2n_stuffer_write_uint32/Makefile.backup
+++ b/tests/cbmc/proofs/s2n_stuffer_write_uint32/Makefile.backup
@@ -1,0 +1,41 @@
+# Copyright Amazon.com, Inc. or its affiliates. All Rights Reserved.
+#
+# Licensed under the Apache License, Version 2.0 (the "License"). You may not use
+# this file except in compliance with the License. A copy of the License is
+# located at
+#
+#     http://aws.amazon.com/apache2.0/
+#
+# or in the "license" file accompanying this file. This file is distributed on an
+# "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or
+# implied. See the License for the specific language governing permissions and
+# limitations under the License.
+
+# Expected runtime is 50 seconds.
+SIZEOF_UINT32 = 4
+
+CBMCFLAGS +=
+
+PROOF_UID = s2n_stuffer_write_uint32
+HARNESS_ENTRY = $(PROOF_UID)_harness
+HARNESS_FILE = $(HARNESS_ENTRY).c
+
+PROOF_SOURCES += $(PROOFDIR)/$(HARNESS_FILE)
+PROOF_SOURCES += $(PROOF_SOURCE)/cbmc_utils.c
+PROOF_SOURCES += $(PROOF_SOURCE)/make_common_datastructures.c
+
+PROJECT_SOURCES += $(SRCDIR)/stuffer/s2n_stuffer.c
+PROJECT_SOURCES += $(SRCDIR)/stuffer/s2n_stuffer_network_order.c
+PROJECT_SOURCES += $(SRCDIR)/utils/s2n_blob.c
+PROJECT_SOURCES += $(SRCDIR)/utils/s2n_ensure.c
+PROJECT_SOURCES += $(SRCDIR)/utils/s2n_mem.c
+PROJECT_SOURCES += $(SRCDIR)/utils/s2n_safety.c
+PROJECT_SOURCES += $(SRCDIR)/utils/s2n_result.c
+
+# We abstract these functions because manual inspection demonstrates they are unreachable.
+REMOVE_FUNCTION_BODY += s2n_blob_slice
+REMOVE_FUNCTION_BODY += s2n_stuffer_wipe
+
+UNWINDSET += s2n_stuffer_write_network_order.4:$(shell echo $$((1 + $(SIZEOF_UINT32))))
+
+include ../Makefile.common

--- a/tests/cbmc/proofs/s2n_stuffer_write_uint64/Makefile
+++ b/tests/cbmc/proofs/s2n_stuffer_write_uint64/Makefile
@@ -1,4 +1,3 @@
-# Copyright Amazon.com, Inc. or its affiliates. All Rights Reserved.
 #
 # Licensed under the Apache License, Version 2.0 (the "License"). You may not use
 # this file except in compliance with the License. A copy of the License is

--- a/tests/cbmc/proofs/s2n_stuffer_write_uint64/Makefile.backup
+++ b/tests/cbmc/proofs/s2n_stuffer_write_uint64/Makefile.backup
@@ -1,0 +1,41 @@
+# Copyright Amazon.com, Inc. or its affiliates. All Rights Reserved.
+#
+# Licensed under the Apache License, Version 2.0 (the "License"). You may not use
+# this file except in compliance with the License. A copy of the License is
+# located at
+#
+#     http://aws.amazon.com/apache2.0/
+#
+# or in the "license" file accompanying this file. This file is distributed on an
+# "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or
+# implied. See the License for the specific language governing permissions and
+# limitations under the License.
+
+# Expected runtime is 50 seconds.
+SIZEOF_UINT64 = 8
+
+CBMCFLAGS +=
+
+PROOF_UID = s2n_stuffer_write_uint64
+HARNESS_ENTRY = $(PROOF_UID)_harness
+HARNESS_FILE = $(HARNESS_ENTRY).c
+
+PROOF_SOURCES += $(PROOFDIR)/$(HARNESS_FILE)
+PROOF_SOURCES += $(PROOF_SOURCE)/cbmc_utils.c
+PROOF_SOURCES += $(PROOF_SOURCE)/make_common_datastructures.c
+
+PROJECT_SOURCES += $(SRCDIR)/stuffer/s2n_stuffer.c
+PROJECT_SOURCES += $(SRCDIR)/stuffer/s2n_stuffer_network_order.c
+PROJECT_SOURCES += $(SRCDIR)/utils/s2n_blob.c
+PROJECT_SOURCES += $(SRCDIR)/utils/s2n_ensure.c
+PROJECT_SOURCES += $(SRCDIR)/utils/s2n_mem.c
+PROJECT_SOURCES += $(SRCDIR)/utils/s2n_safety.c
+PROJECT_SOURCES += $(SRCDIR)/utils/s2n_result.c
+
+# We abstract these functions because manual inspection demonstrates they are unreachable.
+REMOVE_FUNCTION_BODY += s2n_blob_slice
+REMOVE_FUNCTION_BODY += s2n_stuffer_wipe
+
+UNWINDSET += s2n_stuffer_write_network_order.4:$(shell echo $$((1 + $(SIZEOF_UINT64))))
+
+include ../Makefile.common

--- a/tests/cbmc/proofs/s2n_stuffer_write_uint8/Makefile
+++ b/tests/cbmc/proofs/s2n_stuffer_write_uint8/Makefile
@@ -1,4 +1,3 @@
-# Copyright Amazon.com, Inc. or its affiliates. All Rights Reserved.
 #
 # Licensed under the Apache License, Version 2.0 (the "License"). You may not use
 # this file except in compliance with the License. A copy of the License is

--- a/tests/cbmc/proofs/s2n_stuffer_write_uint8/Makefile.backup
+++ b/tests/cbmc/proofs/s2n_stuffer_write_uint8/Makefile.backup
@@ -1,0 +1,41 @@
+# Copyright Amazon.com, Inc. or its affiliates. All Rights Reserved.
+#
+# Licensed under the Apache License, Version 2.0 (the "License"). You may not use
+# this file except in compliance with the License. A copy of the License is
+# located at
+#
+#     http://aws.amazon.com/apache2.0/
+#
+# or in the "license" file accompanying this file. This file is distributed on an
+# "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or
+# implied. See the License for the specific language governing permissions and
+# limitations under the License.
+
+# Expected runtime is 30 seconds.
+
+CBMCFLAGS +=
+
+PROOF_UID = s2n_stuffer_write_uint8
+HARNESS_ENTRY = $(PROOF_UID)_harness
+HARNESS_FILE = $(HARNESS_ENTRY).c
+
+PROOF_SOURCES += $(PROOFDIR)/$(HARNESS_FILE)
+PROOF_SOURCES += $(PROOF_SOURCE)/cbmc_utils.c
+PROOF_SOURCES += $(PROOF_SOURCE)/make_common_datastructures.c
+
+PROJECT_SOURCES += $(SRCDIR)/stuffer/s2n_stuffer.c
+PROJECT_SOURCES += $(SRCDIR)/stuffer/s2n_stuffer_network_order.c
+PROJECT_SOURCES += $(SRCDIR)/utils/s2n_blob.c
+PROJECT_SOURCES += $(SRCDIR)/utils/s2n_ensure.c
+PROJECT_SOURCES += $(SRCDIR)/utils/s2n_mem.c
+PROJECT_SOURCES += $(SRCDIR)/utils/s2n_safety.c
+PROJECT_SOURCES += $(SRCDIR)/utils/s2n_result.c
+
+# We abstract these functions because manual inspection demonstrates they are unreachable.
+REMOVE_FUNCTION_BODY += s2n_blob_slice
+REMOVE_FUNCTION_BODY += __CPROVER_file_local_s2n_mem_c_s2n_mem_cleanup_impl
+REMOVE_FUNCTION_BODY += s2n_stuffer_wipe
+
+UNWINDSET +=
+
+include ../Makefile.common

--- a/tests/cbmc/proofs/s2n_stuffer_write_vector_size/Makefile
+++ b/tests/cbmc/proofs/s2n_stuffer_write_vector_size/Makefile
@@ -1,4 +1,3 @@
-# Copyright Amazon.com, Inc. or its affiliates. All Rights Reserved.
 #
 # Licensed under the Apache License, Version 2.0 (the "License"). You may not use
 # this file except in compliance with the License. A copy of the License is

--- a/tests/cbmc/proofs/s2n_stuffer_write_vector_size/Makefile.backup
+++ b/tests/cbmc/proofs/s2n_stuffer_write_vector_size/Makefile.backup
@@ -1,0 +1,56 @@
+# Copyright Amazon.com, Inc. or its affiliates. All Rights Reserved.
+#
+# Licensed under the Apache License, Version 2.0 (the "License"). You may not use
+# this file except in compliance with the License. A copy of the License is
+# located at
+#
+#     http://aws.amazon.com/apache2.0/
+#
+# or in the "license" file accompanying this file. This file is distributed on an
+# "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or
+# implied. See the License for the specific language governing permissions and
+# limitations under the License.
+
+# Expected runtime is 18 minutes.
+
+# This the the maximum number of iterations to unroll
+# the loop in s2n_stuffer_write_network_order
+MAX_WRITE_NETWORK_ORDER = 9
+
+CBMCFLAGS +=
+
+PROOF_UID = s2n_stuffer_write_vector_size
+HARNESS_ENTRY = $(PROOF_UID)_harness
+HARNESS_FILE = $(HARNESS_ENTRY).c
+
+PROOF_SOURCES += $(PROOFDIR)/$(HARNESS_FILE)
+PROOF_SOURCES += $(PROOF_SOURCE)/cbmc_utils.c
+PROOF_SOURCES += $(PROOF_SOURCE)/make_common_datastructures.c
+PROOF_SOURCES += $(PROOF_STUB)/s2n_calculate_stacktrace.c
+PROOF_SOURCES += $(PROOF_STUB)/sysconf.c
+
+PROJECT_SOURCES += $(SRCDIR)/stuffer/s2n_stuffer.c
+PROJECT_SOURCES += $(SRCDIR)/stuffer/s2n_stuffer_network_order.c
+PROJECT_SOURCES += $(SRCDIR)/utils/s2n_blob.c
+PROJECT_SOURCES += $(SRCDIR)/utils/s2n_ensure.c
+PROJECT_SOURCES += $(SRCDIR)/utils/s2n_mem.c
+PROJECT_SOURCES += $(SRCDIR)/utils/s2n_safety.c
+PROJECT_SOURCES += $(SRCDIR)/utils/s2n_result.c
+
+# We abstract these functions because manual inspection demonstrates they are unreachable.
+REMOVE_FUNCTION_BODY += s2n_add_overflow
+REMOVE_FUNCTION_BODY += s2n_blob_slice
+REMOVE_FUNCTION_BODY += s2n_stuffer_resize
+REMOVE_FUNCTION_BODY += s2n_stuffer_wipe_n
+REMOVE_FUNCTION_BODY += __CPROVER_file_local_s2n_mem_c_s2n_mem_cleanup_impl
+
+UNWINDSET += s2n_stuffer_write_network_order.0:$(MAX_WRITE_NETWORK_ORDER)
+UNWINDSET += s2n_stuffer_write_network_order.1:$(MAX_WRITE_NETWORK_ORDER)
+UNWINDSET += s2n_stuffer_write_network_order.2:$(MAX_WRITE_NETWORK_ORDER)
+UNWINDSET += s2n_stuffer_write_network_order.3:$(MAX_WRITE_NETWORK_ORDER)
+UNWINDSET += s2n_stuffer_write_network_order.4:$(MAX_WRITE_NETWORK_ORDER)
+UNWINDSET += s2n_stuffer_write_network_order.5:$(MAX_WRITE_NETWORK_ORDER)
+UNWINDSET += s2n_stuffer_write_network_order.6:$(MAX_WRITE_NETWORK_ORDER)
+UNWINDSET += s2n_stuffer_write_network_order.7:$(MAX_WRITE_NETWORK_ORDER)
+
+include ../Makefile.common

--- a/tests/cbmc/proofs/s2n_stuffer_writev_bytes/Makefile
+++ b/tests/cbmc/proofs/s2n_stuffer_writev_bytes/Makefile
@@ -1,4 +1,3 @@
-# Copyright Amazon.com, Inc. or its affiliates. All Rights Reserved.
 #
 # Licensed under the Apache License, Version 2.0 (the "License"). You may not use
 # this file except in compliance with the License. A copy of the License is

--- a/tests/cbmc/proofs/s2n_stuffer_writev_bytes/Makefile.backup
+++ b/tests/cbmc/proofs/s2n_stuffer_writev_bytes/Makefile.backup
@@ -1,0 +1,52 @@
+# Copyright Amazon.com, Inc. or its affiliates. All Rights Reserved.
+#
+# Licensed under the Apache License, Version 2.0 (the "License"). You may not use
+# this file except in compliance with the License. A copy of the License is
+# located at
+#
+#     http://aws.amazon.com/apache2.0/
+#
+# or in the "license" file accompanying this file. This file is distributed on an
+# "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or
+# implied. See the License for the specific language governing permissions and
+# limitations under the License.
+
+# Enough to get full coverage with 8 minutes of runtime.
+MAX_IOVEC_SIZE = 3
+DEFINES += -DMAX_IOVEC_SIZE=$(MAX_IOVEC_SIZE)
+DEFINES += -DMADV_DONTDUMP=1
+
+CBMCFLAGS +=
+
+PROOF_UID = s2n_stuffer_writev_bytes
+HARNESS_ENTRY = $(PROOF_UID)_harness
+HARNESS_FILE = $(HARNESS_ENTRY).c
+
+PROOF_SOURCES += $(PROOFDIR)/$(HARNESS_FILE)
+PROOF_SOURCES += $(PROOF_SOURCE)/cbmc_utils.c
+PROOF_SOURCES += $(PROOF_SOURCE)/make_common_datastructures.c
+PROOF_SOURCES += $(PROOF_STUB)/madvise.c
+PROOF_SOURCES += $(PROOF_STUB)/memcpy_havoc.c
+PROOF_SOURCES += $(PROOF_STUB)/mlock.c
+PROOF_SOURCES += $(PROOF_STUB)/munlock.c
+PROOF_SOURCES += $(PROOF_STUB)/posix_memalign_override.c
+PROOF_SOURCES += $(PROOF_STUB)/s2n_calculate_stacktrace.c
+PROOF_SOURCES += $(PROOF_STUB)/sysconf.c
+
+PROJECT_SOURCES += $(SRCDIR)/stuffer/s2n_stuffer.c
+PROJECT_SOURCES += $(SRCDIR)/utils/s2n_blob.c
+PROJECT_SOURCES += $(SRCDIR)/utils/s2n_ensure.c
+PROJECT_SOURCES += $(SRCDIR)/utils/s2n_mem.c
+PROJECT_SOURCES += $(SRCDIR)/utils/s2n_safety.c
+PROJECT_SOURCES += $(SRCDIR)/utils/s2n_result.c
+
+# We abstract these functions because manual inspection demonstrates they are unreachable.
+REMOVE_FUNCTION_BODY += s2n_blob_slice
+REMOVE_FUNCTION_BODY += s2n_stuffer_wipe
+REMOVE_FUNCTION_BODY += s2n_stuffer_wipe_n
+REMOVE_FUNCTION_BODY += __CPROVER_file_local_s2n_mem_c_s2n_mem_cleanup_impl
+
+UNWINDSET += s2n_stuffer_writev_bytes.18:$(call addone,$(MAX_IOVEC_SIZE))
+UNWINDSET += s2n_stuffer_writev_bytes_harness.0:$(call addone,$(MAX_IOVEC_SIZE))
+
+include ../Makefile.common

--- a/tests/cbmc/proofs/s2n_sub_overflow/Makefile
+++ b/tests/cbmc/proofs/s2n_sub_overflow/Makefile
@@ -1,4 +1,3 @@
-# Copyright Amazon.com, Inc. or its affiliates. All Rights Reserved.
 #
 # Licensed under the Apache License, Version 2.0 (the "License"). You may not use
 # this file except in compliance with the License. A copy of the License is

--- a/tests/cbmc/proofs/s2n_sub_overflow/Makefile.backup
+++ b/tests/cbmc/proofs/s2n_sub_overflow/Makefile.backup
@@ -1,0 +1,30 @@
+# Copyright Amazon.com, Inc. or its affiliates. All Rights Reserved.
+#
+# Licensed under the Apache License, Version 2.0 (the "License"). You may not use
+# this file except in compliance with the License. A copy of the License is
+# located at
+#
+#     http://aws.amazon.com/apache2.0/
+#
+# or in the "license" file accompanying this file. This file is distributed on an
+# "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or
+# implied. See the License for the specific language governing permissions and
+# limitations under the License.
+
+# Expected runtime is 10 seconds.
+
+CBMCFLAGS +=
+
+PROOF_UID = s2n_sub_overflow
+HARNESS_ENTRY = $(PROOF_UID)_harness
+HARNESS_FILE = $(HARNESS_ENTRY).c
+
+PROOF_SOURCES += $(PROOFDIR)/$(HARNESS_FILE)
+
+PROOF_SOURCES += $(PROOF_STUB)/s2n_calculate_stacktrace.c
+
+PROJECT_SOURCES += $(SRCDIR)/utils/s2n_safety.c
+
+UNWINDSET +=
+
+include ../Makefile.common

--- a/tests/cbmc/sources/README.md
+++ b/tests/cbmc/sources/README.md
@@ -1,1 +1,6 @@
-../templates/template-for-repository/sources/README.md
+CBMC proof source code
+======================
+
+This directory contains source code written for CBMC proofs.  It is
+common to write some code to model aspects of the system under test,
+and this code goes here.

--- a/tests/cbmc/stubs/README.md
+++ b/tests/cbmc/stubs/README.md
@@ -1,1 +1,6 @@
-../templates/template-for-repository/stubs/README.md
+CBMC proof stubs
+======================
+
+This directory contains the stubs written for CBMC proofs.  It is
+common to stub out functionality like network send and receive methods
+when writing a CBMC proof, and the code for these stubs goes here.

--- a/tests/saw/sike_r1/proof/sidh.saw
+++ b/tests/saw/sike_r1/proof/sidh.saw
@@ -29,6 +29,15 @@ let fp2_encode_spec = do {
     crucible_points_to encp (tm enc);
 };
 
+let sike_p503_r1_publickey_validation_spec = do {
+    // Assume that sike_p503_r1_publickey_validation() always returns zero, and does not have any side effects when 
+    // called with pointers to two disjoint memory regions.
+    PKBp <- crucible_alloc_readonly f2elm_t;
+    Ap <- crucible_alloc_readonly f2elm_t;
+    crucible_execute_func [PKBp, Ap];
+    crucible_return (crucible_term {{ 0:[32] }});
+};
+
 let random_mod_order_B_spec = do {
     random_digits_p <- crucible_alloc (llvm_array SECRETKEY_B_BYTES char_t);
     crucible_execute_func [random_digits_p];
@@ -89,6 +98,8 @@ fp2_encode_ov <- verify fp2_encode_fun_name
     [from_fp2mont_ov]
     fp2_encode_spec;
 
+sike_p503_r1_publickey_validation_ov <- crucible_llvm_unsafe_assume_spec m sike_p503_r1_publickey_validation_fun_name sike_p503_r1_publickey_validation_spec;
+
 let O_base_Key =
     [ fpcopy_ov
     , fpzero_ov
@@ -118,7 +129,8 @@ let O_base_KeyA = concat O_base_Key [ LADDER3PT_A_ov ];
 let O_base_KeyB = concat O_base_Key [ LADDER3PT_B_ov ];
 
 let O_base_Secret =
-    [ fpcopy_ov
+    [ sike_p503_r1_publickey_validation_ov
+    , fpcopy_ov
     , fpzero_ov
     , fp2copy_ov
     , fp2add_ov

--- a/tests/saw/sike_r1/proof/sike_r1_defs.saw
+++ b/tests/saw/sike_r1/proof/sike_r1_defs.saw
@@ -87,6 +87,7 @@ let random_mod_order_B_fun_name = "random_mod_order_B_r1";
 let init_basis_fun_name = "init_basis_r1";
 let fp2_decode_fun_name = "fp2_decode_r1";
 let fp2_encode_fun_name = "fp2_encode_r1";
+let sike_p503_r1_publickey_validation_fun_name = "sike_p503_r1_publickey_validation";
 let EphemeralKeyGeneration_A_fun_name = "EphemeralKeyGeneration_A_r1";
 let EphemeralKeyGeneration_B_fun_name = "EphemeralKeyGeneration_B_r1";
 let EphemeralSecretAgreement_A_fun_name = "EphemeralSecretAgreement_A_r1";


### PR DESCRIPTION
### Description of changes: 

- Update the CBMC starter kit. Within `test/cbmc` I ran `cbmc-starter-kit-update --remove-starter-kit-submodule` upon having installed the latest version of the CBMC starter kit.
- Update licenses referenced in Makefiles belonging to CBMC proofs

By submitting this pull request, I confirm that my contribution is made under the terms of the Apache 2.0 license.
